### PR TITLE
Update NPC text IDs

### DIFF
--- a/conf/transmog.conf.dist
+++ b/conf/transmog.conf.dist
@@ -183,7 +183,7 @@ Transmogrification.IgnoreReqStats = 0
 #
 #    Transmogrification.SetNpcText
 #        Description: The npc_text entry of the info menu for the set feature
-#        Default:    50001
+#        Default:    500001
 #
 #    Transmogrification.SetCostModifier
 #        Description: A multiplier for the default gold cost (all costs summed together) (change to 0 for no default cost)
@@ -197,7 +197,7 @@ Transmogrification.EnableSets = 1
 Transmogrification.MaxSets = 10
 
 Transmogrification.EnableSetInfo = 1
-Transmogrification.SetNpcText = 50001
+Transmogrification.SetNpcText = 500001
 
 Transmogrification.SetCostModifier = 3.0
 Transmogrification.SetCopperCost = 0

--- a/conf/transmog.conf.dist
+++ b/conf/transmog.conf.dist
@@ -17,7 +17,7 @@
 #
 #    Transmogrification.TransmogNpcText
 #        Description: The npc_text entry of the info menu for transmogrification
-#        Default:    50000
+#        Default:    500000
 #
 #    Transmogrification.Allowed
 #        Description: A list of item entries that are allowed for transmogrification (skips quality and CanUseItem check)
@@ -30,7 +30,7 @@
 #        Default:    ""
 
 Transmogrification.EnableTransmogInfo = 1
-Transmogrification.TransmogNpcText = 50000
+Transmogrification.TransmogNpcText = 500000
 
 Transmogrification.Allowed = ""
 Transmogrification.NotAllowed = ""

--- a/data/sql/db-world/trasm_world_texts.sql
+++ b/data/sql/db-world/trasm_world_texts.sql
@@ -1,4 +1,4 @@
-SET @TEXT_ID := 50000;
+SET @TEXT_ID := 500000;
 DELETE FROM `npc_text` WHERE `ID` IN  (@TEXT_ID,@TEXT_ID+1);
 INSERT INTO `npc_text` (`ID`, `text0_0`) VALUES
 (@TEXT_ID, 'Transmogrification allows you to change how your items look like without changing the stats of the items.\r\nItems used in transmogrification are no longer refundable, tradeable and are bound to you.\r\nUpdating a menu updates the view and prices.\r\n\r\nNot everything can be transmogrified with eachother.\r\nRestrictions include but are not limited to:\r\nOnly armor and weapons can be transmogrified\r\nGuns, bows and crossbows can be transmogrified with eachother\r\nFishing poles can not be transmogrified\r\nYou must be able to equip both items used in the process.\r\n\r\nTransmogrifications stay on your items as long as you own them.\r\nIf you try to put the item in guild bank or mail it to someone else, the transmogrification is stripped.\r\n\r\nYou can also remove transmogrifications for free at the transmogrifier.'),

--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -595,7 +595,7 @@ void Transmogrification::LoadConfig(bool reload)
 #endif
 
     EnableTransmogInfo = sConfigMgr->GetBoolDefault("Transmogrification.EnableTransmogInfo", true);
-    TransmogNpcText = uint32(sConfigMgr->GetIntDefault("Transmogrification.TransmogNpcText", 50000));
+    TransmogNpcText = uint32(sConfigMgr->GetIntDefault("Transmogrification.TransmogNpcText", 500000));
 
     std::istringstream issAllowed(sConfigMgr->GetStringDefault("Transmogrification.Allowed", ""));
     std::istringstream issNotAllowed(sConfigMgr->GetStringDefault("Transmogrification.NotAllowed", ""));

--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -568,7 +568,7 @@ void Transmogrification::LoadConfig(bool reload)
 {
 #ifdef PRESETS
     EnableSetInfo = sConfigMgr->GetBoolDefault("Transmogrification.EnableSetInfo", true);
-    SetNpcText = uint32(sConfigMgr->GetIntDefault("Transmogrification.SetNpcText", 50001));
+    SetNpcText = uint32(sConfigMgr->GetIntDefault("Transmogrification.SetNpcText", 500001));
 
     EnableSets = sConfigMgr->GetBoolDefault("Transmogrification.EnableSets", true);
     MaxSets = (uint8)sConfigMgr->GetIntDefault("Transmogrification.MaxSets", 10);


### PR DESCRIPTION
Change NPC text IDs from 50000 to 500000 and 50001 to 500001 due to a conflict with AC commit https://github.com/azerothcore/azerothcore-wotlk/commit/b34bc28e5b02514fca3519beac420c58faa89cad which uses 50000 and 50001 for other purposes.

Tested build and in-game on Ubuntu 16.04.