### PR TITLE
feat: allow item IDs without restriction

### DIFF
--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -420,10 +420,13 @@ bool Transmogrification::CanTransmogrifyItemWithItem(Player* player, ItemTemplat
 
     if (source->SubClass != target->SubClass && !IsRangedWeapon(target->Class, target->SubClass))
     {
-        if (source->Class == ITEM_CLASS_ARMOR && !AllowMixedArmorTypes)
-            return false;
-        if (source->Class == ITEM_CLASS_WEAPON && !AllowMixedWeaponTypes)
-            return false;
+        if (!IsAllowed(source->ItemId))
+        {
+            if (source->Class == ITEM_CLASS_ARMOR && !AllowMixedArmorTypes)
+                return false;
+            if (source->Class == ITEM_CLASS_WEAPON && !AllowMixedWeaponTypes)
+                return false;
+        }
     }
 
     if (source->InventoryType != target->InventoryType)


### PR DESCRIPTION
Item IDs specified directly via option "Transmogrification.Allowed" are allowed for transmogrification without restriction.

Closes #17 