### PR TITLE
feat(PlayerScript): Ensure compatibility with mod-weapon-visual

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 AC_ADD_SCRIPT("${CMAKE_CURRENT_LIST_DIR}/src/transmog_scripts.cpp")
 AC_ADD_SCRIPT("${CMAKE_CURRENT_LIST_DIR}/src/Transmogrification.cpp")
-AC_ADD_SCRIPT_LOADER("Transmog" "${CMAKE_CURRENT_LIST_DIR}/src/transmog_scripts_loader.h")
+AC_ADD_SCRIPT_LOADER("Transmog" "${CMAKE_CURRENT_LIST_DIR}/src/transmog_scripts_loader.h" "SC_Npc_VisualWeapon")
 
 AC_ADD_CONFIG_FILE("${CMAKE_CURRENT_LIST_DIR}/conf/transmog.conf.dist")

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -378,7 +378,9 @@ public:
     void OnAfterMoveItemFromInventory(Player* /*player*/, Item* it, uint8 /*bag*/, uint8 /*slot*/, bool /*update*/) {
         sT->DeleteFakeFromDB(it->GetGUIDLow());
     }
-    
+
+    // There's a conflict with the module "mod-weapon-visual". Transmog has to be executed before applying weapon visuals, so
+    // use "OnLoadFromDB" instead of "OnLogin", because it is called at the beginning of the login process, "OnLogin" at the end
     void OnLoadFromDB(Player* player)
     {
         uint64 playerGUID = player->GetGUID();

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -379,7 +379,7 @@ public:
         sT->DeleteFakeFromDB(it->GetGUIDLow());
     }
     
-    void OnLogin(Player* player)
+    void OnLoadFromDB(Player* player)
     {
         uint64 playerGUID = player->GetGUID();
         sT->entryMap.erase(playerGUID);

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -378,7 +378,7 @@ public:
     void OnAfterMoveItemFromInventory(Player* /*player*/, Item* it, uint8 /*bag*/, uint8 /*slot*/, bool /*update*/) {
         sT->DeleteFakeFromDB(it->GetGUIDLow());
     }
-
+    
     void OnLogin(Player* player)
     {
         uint64 playerGUID = player->GetGUID();

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -379,9 +379,7 @@ public:
         sT->DeleteFakeFromDB(it->GetGUIDLow());
     }
 
-    // There's a conflict with the module "mod-weapon-visual". Transmog has to be executed before applying weapon visuals, so
-    // use "OnLoadFromDB" instead of "OnLogin", because it is called at the beginning of the login process, "OnLogin" at the end
-    void OnLoadFromDB(Player* player)
+    void OnLogin(Player* player)
     {
         uint64 playerGUID = player->GetGUID();
         sT->entryMap.erase(playerGUID);


### PR DESCRIPTION
Currently if using both mod-transmog and mod-weapon-visual this can result in weapon visuals not shown, because both modules use "OnLogin" to apply their visual modifications.
With commit https://github.com/azerothcore/azerothcore-wotlk/commit/0a9202a82954e9458707e6e4c2b5370fb7d6a7ae it is now possible to lower prioritize other scripts via additional arguments to "AC_ADD_SCRIPT_LOADER". This is now done using the additional argument "SC_Npc_VisualWeapon" which ensures that the mod-transmog gains a higher priority than mod-weapon-visual.

Tested build on Ubuntu 16.04 using clang7; tested successfully in-game with both modules installed.