### PR TITLE
Appearance Collection

### DIFF
--- a/conf/transmog.conf.dist
+++ b/conf/transmog.conf.dist
@@ -12,6 +12,17 @@
 #                     Players won't be able to see any transmogrified item while disabled, however, database data remains intact.
 #        Default:     1
 #
+#    Transmogrification.UseCollectionSystem
+#        Description: Enables/Disables Legion-style appearance collection system.
+#                     If enabled, players can use the appearance of any item equipped or rewarded from a completed quest.
+#                     If disabled, players must have an item in their bags to use as a transmogrification appearance source.
+#        Default:     1
+#
+#    Transmogrification.TrackUnusableItems
+#        Description: If enabled, appearances are collected even for items that are not suitable for transmogrification.
+#                     This allows these appearances to be used later if the configuration is changed.
+#        Default:     1
+#
 #    Transmogrification.EnableTransmogInfo
 #        Description: Enables / Disables the info button for transmogrification
 #        Default:    1
@@ -31,6 +42,8 @@
 #        Default:    ""
 
 Transmogrification.Enable = 1
+Transmogrification.UseCollectionSystem = 1
+Transmogrification.TrackUnusableItems = 1
 
 Transmogrification.EnableTransmogInfo = 1
 Transmogrification.TransmogNpcText = 601083

--- a/data/sql/db-characters/trasmorg.sql
+++ b/data/sql/db-characters/trasmorg.sql
@@ -18,3 +18,9 @@ CREATE TABLE IF NOT EXISTS `custom_transmogrification_sets` (
   `SetData` text COMMENT 'Slot1 Entry1 Slot2 Entry2',
   PRIMARY KEY (`Owner`,`PresetID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='6_1';
+
+CREATE TABLE IF NOT EXISTS `custom_transmog_unlocked_appearances` (
+    `account_id`       int(10) unsigned      NOT NULL,
+    `item_template_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
+    PRIMARY KEY (`account_id`, `item_template_id`)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8;

--- a/data/sql/db-characters/trasmorg.sql
+++ b/data/sql/db-characters/trasmorg.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS `custom_transmogrification_sets` (
   PRIMARY KEY (`Owner`,`PresetID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='6_1';
 
-CREATE TABLE IF NOT EXISTS `custom_transmog_unlocked_appearances` (
+CREATE TABLE IF NOT EXISTS `custom_unlocked_appearances` (
     `account_id`       int(10) unsigned      NOT NULL,
     `item_template_id` mediumint(8) unsigned NOT NULL DEFAULT '0',
     PRIMARY KEY (`account_id`, `item_template_id`)

--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -1,5 +1,5 @@
 #include "Transmogrification.h"
-#include "../../../src/server/game/Entities/Item/ItemTemplate.h"
+#include "ItemTemplate.h"
 
 Transmogrification* Transmogrification::instance()
 {

--- a/src/Transmogrification.h
+++ b/src/Transmogrification.h
@@ -6,6 +6,12 @@
 #include "ScriptMgr.h"
 #include "ScriptedGossip.h"
 #include "GameEventMgr.h"
+#include "Item.h"
+#include "ScriptMgr.h"
+#include "Chat.h"
+#include "ItemTemplate.h"
+#include "QuestDef.h"
+#include "ItemTemplate.h"
 #include <unordered_map>
 #include <vector>
 
@@ -118,6 +124,9 @@ public:
     bool IgnoreReqEvent;
     bool IgnoreReqStats;
 
+    bool UseCollectionSystem;
+    bool TrackUnusableItems;
+
     bool IsTransmogEnabled;
 
     bool IsAllowed(uint32 entry) const;
@@ -138,6 +147,8 @@ public:
     void SetFakeEntry(Player* player, uint32 newEntry, uint8 slot, Item* itemTransmogrified);
 
     TransmogAcoreStrings Transmogrify(Player* player, ObjectGuid itemGUID, uint8 slot, /*uint32 newEntry, */bool no_cost = false);
+    TransmogAcoreStrings Transmogrify(Player* player, uint32 itemEntry, uint8 slot, /*uint32 newEntry, */bool no_cost = false);
+    TransmogAcoreStrings Transmogrify(Player* player, Item* itemTransmogrifier, uint8 slot, /*uint32 newEntry, */bool no_cost = false);
     bool CanTransmogrifyItemWithItem(Player* player, ItemTemplate const* destination, ItemTemplate const* source) const;
     bool SuitableForTransmogrification(Player* player, ItemTemplate const* proto) const;
     // bool CanBeTransmogrified(Item const* item);
@@ -161,6 +172,8 @@ public:
     bool GetEnableSetInfo() const;
     uint32 GetSetNpcText() const;
 
+    bool GetUseCollectionSystem() const;
+    bool GetTrackUnusableItems() const;
     [[nodiscard]] bool IsEnabled() const;
 };
 #define sTransmogrification Transmogrification::instance()

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -539,7 +539,7 @@ public:
         {
             AddToDatabase(player, item->GetTemplate());
         }
-    };
+    }
 
     void OnPlayerCompleteQuest(Player* player, Quest const* quest) override
     {
@@ -563,7 +563,7 @@ public:
         }
     }
 
-    void OnAfterSetVisibleItemSlot(Player* player, uint8 slot, Item *item)
+    void OnAfterSetVisibleItemSlot(Player* player, uint8 slot, Item *item) override
     {
         if (!item)
             return;
@@ -574,12 +574,12 @@ public:
         }
     }
 
-    void OnAfterMoveItemFromInventory(Player* /*player*/, Item* it, uint8 /*bag*/, uint8 /*slot*/, bool /*update*/)
+    void OnAfterMoveItemFromInventory(Player* /*player*/, Item* it, uint8 /*bag*/, uint8 /*slot*/, bool /*update*/) override
     {
         sT->DeleteFakeFromDB(it->GetGUID().GetCounter());
     }
 
-    void OnLogin(Player* player)
+    void OnLogin(Player* player) override
     {
         ObjectGuid playerGUID = player->GetGUID();
         sT->entryMap.erase(playerGUID);

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -615,7 +615,7 @@ public:
 #endif
     }
 
-    void OnLogout(Player* player)
+    void OnLogout(Player* player) override
     {
         ObjectGuid pGUID = player->GetGUID();
         for (Transmogrification::transmog2Data::const_iterator it = sT->entryMap[pGUID].begin(); it != sT->entryMap[pGUID].end(); ++it)
@@ -658,12 +658,12 @@ class global_transmog_script : public GlobalScript
 public:
     global_transmog_script() : GlobalScript("global_transmog_script") { }
 
-    void OnItemDelFromDB(CharacterDatabaseTransaction trans, ObjectGuid::LowType itemGuid)
+    void OnItemDelFromDB(CharacterDatabaseTransaction trans, ObjectGuid::LowType itemGuid) override
     {
         sT->DeleteFakeFromDB(itemGuid, &trans);
     }
 
-    void OnMirrorImageDisplayItem(const Item *item, uint32 &display)
+    void OnMirrorImageDisplayItem(const Item *item, uint32 &display) override
     {
         if (uint32 entry = sTransmogrification->GetFakeEntry(item->GetGUID()))
             display=uint32(sObjectMgr->GetItemTemplate(entry)->DisplayInfoID);

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -357,12 +357,12 @@ public:
             {
                 uint16 pageNumber = 0;
                 uint32 startValue = 1;
-                uint32 endValue = MAX_OPTIONS - 1;
+                uint32 endValue = MAX_OPTIONS - 2;
                 if (gossipPageNumber > EQUIPMENT_SLOT_END + 10)
                 {
                     pageNumber = gossipPageNumber - EQUIPMENT_SLOT_END - 10;
-                    startValue = (pageNumber * MAX_OPTIONS);
-                    endValue = ((pageNumber + 1) * MAX_OPTIONS) - 1;
+                    startValue = (pageNumber * (MAX_OPTIONS - 2)) + 1;
+                    endValue = (pageNumber + 1) * (MAX_OPTIONS - 2);
                 }
                 QueryResult result = CharacterDatabase.Query(
                         "SELECT item_template_id FROM custom_unlocked_appearances WHERE account_id={} ORDER BY item_template_id LIMIT {},{}",
@@ -385,8 +385,14 @@ public:
                         AddGossipItemFor(player, GOSSIP_ICON_MONEY_BAG, sT->GetItemIcon(newItem->GetEntry(), 30, 30, -18, 0) + sT->GetItemLink(newItem, session), slot, newItem->GetEntry(), "Using this item for transmogrify will bind it to you and make it non-refundable and non-tradeable.\nDo you wish to continue?\n\n" + sT->GetItemIcon(newItem->GetEntry(), 40, 40, -15, -10) + sT->GetItemLink(newItem, session) + ss.str(), price, false);
                     } while (result -> NextRow());
                 }
-                if (gossipPageNumber > EQUIPMENT_SLOT_END + 10)
+                if (gossipPageNumber == EQUIPMENT_SLOT_END + 11)
                 {
+                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Previous Page", EQUIPMENT_SLOT_END, 0);
+                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Next Page", gossipPageNumber + 1, 0);
+                }
+                else if (gossipPageNumber > EQUIPMENT_SLOT_END + 11)
+                {
+                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Previous Page", gossipPageNumber - 1, 0);
                     AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Next Page", gossipPageNumber + 1, 0);
                 }
                 else

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -476,9 +476,11 @@ private:
         std::stringstream tempStream;
         tempStream << std::hex << ItemQualityColors[itemTemplate->Quality];
         std::string itemQuality = tempStream.str();
+        bool showChatMessage = !(player->GetPlayerSetting("mod-transmog", SETTING_HIDE_TRANSMOG).value);
         QueryResult result = CharacterDatabase.Query("SELECT account_id, item_template_id FROM custom_unlocked_appearances WHERE account_id={} AND item_template_id={}", playerEntry, itemId);
         if (!result) {
-            ChatHandler(player->GetSession()).PSendSysMessage(R"(|c%s|Hitem:%u:0:0:0:0:0:0:0:0|h[%s]|h|r has been added to your appearance collection.)", itemQuality.c_str(), itemId, itemName.c_str());
+            if (showChatMessage)
+                ChatHandler(player->GetSession()).PSendSysMessage(R"(|c%s|Hitem:%u:0:0:0:0:0:0:0:0|h[%s]|h|r has been added to your appearance collection.)", itemQuality.c_str(), itemId, itemName.c_str());
             CharacterDatabase.Execute("INSERT INTO custom_unlocked_appearances (account_id, item_template_id) VALUES ({}, {})", playerEntry, itemId);
         }
     }

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -394,23 +394,23 @@ public:
                 }
                 if (gossipPageNumber == EQUIPMENT_SLOT_END + 11)
                 {
-                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Previous Page", EQUIPMENT_SLOT_END, 0);
+                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Previous Page", EQUIPMENT_SLOT_END, slot);
                     if (!lastPage)
                     {
-                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Next Page", gossipPageNumber + 1, 0);
+                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Next Page", gossipPageNumber + 1, slot);
                     }
                 }
                 else if (gossipPageNumber > EQUIPMENT_SLOT_END + 11)
                 {
-                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Previous Page", gossipPageNumber - 1, 0);
+                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Previous Page", gossipPageNumber - 1, slot);
                     if (!lastPage)
                     {
-                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Next Page", gossipPageNumber + 1, 0);
+                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Next Page", gossipPageNumber + 1, slot);
                     }
                 }
                 else if (!lastPage)
                 {
-                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Next Page", EQUIPMENT_SLOT_END + 11, 0);
+                    AddGossipItemFor(player, GOSSIP_ICON_CHAT, "Next Page", EQUIPMENT_SLOT_END + 11, slot);
                 }
             }
             else


### PR DESCRIPTION
This PR is implement a Appearance Collection system like later expansions. When an item is equipped or a quest is completed, data is saved to the account. Players can use any of the items they have collected as a transmog candidate, rather than only items in the bag. If this is disabled through config option, behavior will be the same as before and require items in bag to be transmog.
![chatMessage](https://user-images.githubusercontent.com/98835050/155623260-1c2b35f8-ba1e-4d54-8b0c-6a38c961749b.png)
![appearanceSelection](https://user-images.githubusercontent.com/98835050/155623273-e0c64c50-de0e-4893-8789-bf0659b73ea9.PNG)

Because players will now have many more items available for transmog, I have also implemented paging in the gossip menu so that they can browse through many items.

I have created a client addon that can track which item still need to have appearance collected and show tooltip:
![newAppearanceTooltip](https://user-images.githubusercontent.com/98835050/155623313-86918348-8529-4ba8-bc31-d6f7d07cd686.png)

I also have modified version of MogIt that can show collected appearance:
![mogItToolTip](https://user-images.githubusercontent.com/98835050/155623541-029ac6ef-c425-419e-acab-0b109c510c03.png)

Note that these addons still need to manually sync data with server, but this is a separate addon issue not related for this PR.