### PR TITLE
Implement Hidden Transmog option

### DIFF
--- a/conf/transmog.conf.dist
+++ b/conf/transmog.conf.dist
@@ -18,6 +18,11 @@
 #                     If disabled, players must have an item in their bags to use as a transmogrification appearance source.
 #        Default:     1
 #
+#    Transmogrification.AllowHiddenTransmog
+#        Description: Enables/Disables the hiding of equipment through transmog
+#                     If enabled, players can select an "invisible" appearance for items at the transmog vendor
+#        Default:     1
+#
 #    Transmogrification.TrackUnusableItems
 #        Description: If enabled, appearances are collected even for items that are not suitable for transmogrification.
 #                     This allows these appearances to be used later if the configuration is changed.
@@ -43,6 +48,7 @@
 
 Transmogrification.Enable = 1
 Transmogrification.UseCollectionSystem = 1
+Transmogrification.AllowHiddenTransmog = 1
 Transmogrification.TrackUnusableItems = 1
 
 Transmogrification.EnableTransmogInfo = 1

--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -294,8 +294,12 @@ void Transmogrification::SetFakeEntry(Player* player, uint32 newEntry, uint8 /*s
 }
 
 TransmogAcoreStrings Transmogrification::Transmogrify(Player* player, uint32 itemEntry, uint8 slot, /*uint32 newEntry, */bool no_cost) {
+    if (itemEntry == UINT_MAX) // Hidden transmog
+    {
+        return Transmogrify(player, nullptr, slot, no_cost, true);
+    }
     Item* itemTransmogrifier = Item::CreateItem(itemEntry, 1, 0);
-    return Transmogrify(player, itemTransmogrifier, slot, no_cost);
+    return Transmogrify(player, itemTransmogrifier, slot, no_cost, false);
 }
 
 TransmogAcoreStrings Transmogrification::Transmogrify(Player* player, ObjectGuid itemGUID, uint8 slot, /*uint32 newEntry, */bool no_cost) {
@@ -310,10 +314,10 @@ TransmogAcoreStrings Transmogrification::Transmogrify(Player* player, ObjectGuid
             return LANG_ERR_TRANSMOG_MISSING_SRC_ITEM;
         }
     }
-    return Transmogrify(player, itemTransmogrifier, slot, no_cost);
+    return Transmogrify(player, itemTransmogrifier, slot, no_cost, false);
 }
 
-TransmogAcoreStrings Transmogrification::Transmogrify(Player* player, Item* itemTransmogrifier, uint8 slot, /*uint32 newEntry, */bool no_cost)
+TransmogAcoreStrings Transmogrification::Transmogrify(Player* player, Item* itemTransmogrifier, uint8 slot, /*uint32 newEntry, */bool no_cost, bool hidden_transmog)
 {
     int32 cost = 0;
     // slot of the transmogrified item
@@ -329,6 +333,12 @@ TransmogAcoreStrings Transmogrification::Transmogrify(Player* player, Item* item
     {
         //TC_LOG_DEBUG(LOG_FILTER_NETWORKIO, "WORLD: HandleTransmogrifyItems - Player (GUID: {}, name: {}) tried to transmogrify an invalid item in a valid slot (slot: {}).", player->GetGUIDLow(), player->GetName(), slot);
         return LANG_ERR_TRANSMOG_MISSING_DEST_ITEM;
+    }
+
+    if (hidden_transmog)
+    {
+        SetFakeEntry(player, HIDDEN_ITEM_ID, slot, itemTransmogrified); // newEntry
+        return LANG_ERR_TRANSMOG_OK;
     }
 
     if (!itemTransmogrifier) // reset look newEntry
@@ -673,6 +683,7 @@ void Transmogrification::LoadConfig(bool reload)
     IgnoreReqEvent = sConfigMgr->GetOption<bool>("Transmogrification.IgnoreReqEvent", false);
     IgnoreReqStats = sConfigMgr->GetOption<bool>("Transmogrification.IgnoreReqStats", false);
     UseCollectionSystem = sConfigMgr->GetOption<bool>("Transmogrification.UseCollectionSystem", true);
+    AllowHiddenTransmog = sConfigMgr->GetOption<bool>("Transmogrification.AllowHiddenTransmog", true);
     TrackUnusableItems = sConfigMgr->GetOption<bool>("Transmogrification.TrackUnusableItems", true);
 
     IsTransmogEnabled = sConfigMgr->GetOption<bool>("Transmogrification.Enable", true);
@@ -747,6 +758,11 @@ bool Transmogrification::GetUseCollectionSystem() const
 {
     return UseCollectionSystem;
 };
+
+bool Transmogrification::GetAllowHiddenTransmog() const
+{
+    return AllowHiddenTransmog;
+}
 
 bool Transmogrification::GetTrackUnusableItems() const
 {

--- a/src/Transmogrification.h
+++ b/src/Transmogrification.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #define PRESETS // comment this line to disable preset feature totally
+#define HIDDEN_ITEM_ID 1 // used for hidden transmog - do not use a valid equipment ID
 #define MAX_OPTIONS 25 // do not alter
 
 class Item;
@@ -125,6 +126,7 @@ public:
     bool IgnoreReqStats;
 
     bool UseCollectionSystem;
+    bool AllowHiddenTransmog;
     bool TrackUnusableItems;
 
     bool IsTransmogEnabled;
@@ -148,7 +150,7 @@ public:
 
     TransmogAcoreStrings Transmogrify(Player* player, ObjectGuid itemGUID, uint8 slot, /*uint32 newEntry, */bool no_cost = false);
     TransmogAcoreStrings Transmogrify(Player* player, uint32 itemEntry, uint8 slot, /*uint32 newEntry, */bool no_cost = false);
-    TransmogAcoreStrings Transmogrify(Player* player, Item* itemTransmogrifier, uint8 slot, /*uint32 newEntry, */bool no_cost = false);
+    TransmogAcoreStrings Transmogrify(Player* player, Item* itemTransmogrifier, uint8 slot, /*uint32 newEntry, */bool no_cost = false, bool hidden_transmog = false);
     bool CanTransmogrifyItemWithItem(Player* player, ItemTemplate const* destination, ItemTemplate const* source) const;
     bool SuitableForTransmogrification(Player* player, ItemTemplate const* proto) const;
     // bool CanBeTransmogrified(Item const* item);
@@ -173,6 +175,7 @@ public:
     uint32 GetSetNpcText() const;
 
     bool GetUseCollectionSystem() const;
+    bool GetAllowHiddenTransmog() const;
     bool GetTrackUnusableItems() const;
     [[nodiscard]] bool IsEnabled() const;
 };


### PR DESCRIPTION
Adds option that players can set item to "invisible" transmog. This can be disabled through the config.

Note that because items that have been transmog use the icon of the transmog source in the equipment UI frame, this means that items transmog to hidden will appear as empty item slot in equipment frame. The correct icon appears elsewhere, so I think this shouldn't be a problem.

Closes https://github.com/azerothcore/mod-transmog/issues/42.