### PR TITLE
feat: Appearance collection add Item(Set) commands

### DIFF
--- a/data/sql/db-world/trasm_world_texts.sql
+++ b/data/sql/db-world/trasm_world_texts.sql
@@ -22,7 +22,8 @@ INSERT INTO `acore_string` (`entry`, `content_default`) VALUES
 (@STRING_ENTRY+12, 'Hiding transmogrifieded items, relog to update the current area.'),
 (@STRING_ENTRY+13, 'The selected Item is not suitable for transmogrification.');
 
-DELETE FROM `command` WHERE `name` IN ('transmog', 'transmog add');
+DELETE FROM `command` WHERE `name` IN ('transmog', 'transmog add', 'transmog add set');
 INSERT INTO `command` (`name`, `security`, `help`) VALUES
 ('transmog', 0, 'Syntax: .transmog <on/off>\nAllows seeing transmogrified items and the transmogrifier NPC.'),
-('transmog add', 1, 'Syntax: .transmog add $player $item\nAdds an item to a player\'s appearance collection.');
+('transmog add', 1, 'Syntax: .transmog add $player $item\nAdds an item to a player\'s appearance collection.'),
+('transmog add set', 1, 'Syntax: .transmog add set $player $itemSet\nAdds items of an ItemSet to a player\'s appearance collection.');

--- a/data/sql/db-world/trasm_world_texts.sql
+++ b/data/sql/db-world/trasm_world_texts.sql
@@ -5,7 +5,7 @@ INSERT INTO `npc_text` (`ID`, `text0_0`) VALUES
 (@TEXT_ID+1, 'You can save your own transmogrification sets.\r\n\r\nTo save, first you must transmogrify your equipped items.\r\nThen when you go to the set management menu and go to save set menu,\r\nall items you have transmogrified are displayed so you see what you are saving.\r\nIf you think the set is fine, you can click to save the set and name it as you wish.\r\n\r\nTo use a set you can click the saved set in the set management menu and then select use set.\r\nIf the set has a transmogrification for an item that is already transmogrified, the old transmogrification is lost.\r\nNote that same transmogrification restrictions apply when trying to use a set as in normal transmogrification.\r\n\r\nTo delete a set you can go to the set\'s menu and select delete set.');
 
 SET @STRING_ENTRY := 11100;
-DELETE FROM `acore_string` WHERE `entry` IN  (@STRING_ENTRY+0,@STRING_ENTRY+1,@STRING_ENTRY+2,@STRING_ENTRY+3,@STRING_ENTRY+4,@STRING_ENTRY+5,@STRING_ENTRY+6,@STRING_ENTRY+7,@STRING_ENTRY+8,@STRING_ENTRY+9,@STRING_ENTRY+10, @STRING_ENTRY+11, @STRING_ENTRY+12);
+DELETE FROM `acore_string` WHERE `entry` IN  (@STRING_ENTRY+0,@STRING_ENTRY+1,@STRING_ENTRY+2,@STRING_ENTRY+3,@STRING_ENTRY+4,@STRING_ENTRY+5,@STRING_ENTRY+6,@STRING_ENTRY+7,@STRING_ENTRY+8,@STRING_ENTRY+9,@STRING_ENTRY+10, @STRING_ENTRY+11, @STRING_ENTRY+12, @STRING_ENTRY+13);
 INSERT INTO `acore_string` (`entry`, `content_default`) VALUES
 (@STRING_ENTRY+0, 'Item successfully transmogrified.'),
 (@STRING_ENTRY+1, 'Equipment slot is empty.'),
@@ -19,8 +19,10 @@ INSERT INTO `acore_string` (`entry`, `content_default`) VALUES
 (@STRING_ENTRY+9, 'No transmogrification found.'),
 (@STRING_ENTRY+10, 'Invalid name inserted.'),
 (@STRING_ENTRY+11, 'Showing transmogrifieded items, relog to update the current area.'),
-(@STRING_ENTRY+12, 'Hiding transmogrifieded items, relog to update the current area.');
+(@STRING_ENTRY+12, 'Hiding transmogrifieded items, relog to update the current area.'),
+(@STRING_ENTRY+13, 'The selected Item is not suitable for transmogrification.');
 
-DELETE FROM `command` WHERE `name` IN ('transmog');
+DELETE FROM `command` WHERE `name` IN ('transmog', 'transmog add');
 INSERT INTO `command` (`name`, `security`, `help`) VALUES
-('transmog', 0, 'Syntax: .transmog <on/off>\nAllows seeing transmogrified items and the transmogrifier NPC.');
+('transmog', 0, 'Syntax: .transmog <on/off>\nAllows seeing transmogrified items and the transmogrifier NPC.'),
+('transmog add', 1, 'Syntax: .transmog add $player $item\nAdds an item to a player\'s appearance collection.');

--- a/src/Transmogrification.h
+++ b/src/Transmogrification.h
@@ -47,6 +47,7 @@ enum TransmogAcoreStrings // Language.h might have same entries, appears when ex
 #endif
     LANG_CMD_TRANSMOG_SHOW = 11111,
     LANG_CMD_TRANSMOG_HIDE = 11112,
+    LANG_CMD_TRANSMOG_ADD = 11113,
 };
 
 class Transmogrification


### PR DESCRIPTION
### Description
- Adds commands to add an Item or ItemSet to the appearance collection of a player without actually rewarding the Item itself.

### Usage
-  `.transmog add $player? $itemid/$itemlink`
-  `.transmog add $player? $ItemSet`

### Known Issues
- [ ] Will conflict with #80