### PR TITLE
Add config option to allow adding tradeable/refundable items to appearance collection.

### DIFF
--- a/conf/transmog.conf.dist
+++ b/conf/transmog.conf.dist
@@ -127,6 +127,10 @@ Transmogrification.TokenAmount = 1
 #        Description: Allow heirloom quality items to be used as source and target items
 #        Default:    1
 #
+#    Transmogrification.AllowTradeable
+#        Description: Allow items that are tradeable (i.e. During 2 hour grace period during an instance)
+#        Default:    0
+#
 #    Transmogrification.AllowMixedArmorTypes
 #        Description: Allow cloth items to be transmogrified with plate for example
 #        Default:    0
@@ -175,6 +179,7 @@ Transmogrification.AllowEpic = 1
 Transmogrification.AllowLegendary = 0
 Transmogrification.AllowArtifact = 0
 Transmogrification.AllowHeirloom = 1
+Transmogrification.AllowTradeable = 0
 
 Transmogrification.AllowMixedArmorTypes = 0
 Transmogrification.AllowMixedWeaponTypes = 0

--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -876,6 +876,11 @@ bool Transmogrification::GetAllowHiddenTransmog() const
     return AllowHiddenTransmog;
 }
 
+bool Transmogrification::GetAllowTradeable() const
+{
+    return AllowTradeable;
+}
+
 bool Transmogrification::GetTrackUnusableItems() const
 {
     return TrackUnusableItems;

--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -781,6 +781,7 @@ void Transmogrification::LoadConfig(bool reload)
     AllowLegendary = sConfigMgr->GetOption<bool>("Transmogrification.AllowLegendary", false);
     AllowArtifact = sConfigMgr->GetOption<bool>("Transmogrification.AllowArtifact", false);
     AllowHeirloom = sConfigMgr->GetOption<bool>("Transmogrification.AllowHeirloom", true);
+    AllowTradeable = sConfigMgr->GetOption<bool>("Transmogrification.AllowTradeable", false);
 
     AllowMixedArmorTypes = sConfigMgr->GetOption<bool>("Transmogrification.AllowMixedArmorTypes", false);
     AllowMixedWeaponTypes = sConfigMgr->GetOption<bool>("Transmogrification.AllowMixedWeaponTypes", false);

--- a/src/Transmogrification.h
+++ b/src/Transmogrification.h
@@ -116,6 +116,7 @@ public:
     bool AllowLegendary;
     bool AllowArtifact;
     bool AllowHeirloom;
+    bool AllowTradeable;
 
     bool AllowMixedArmorTypes;
     bool AllowMixedWeaponTypes;
@@ -178,6 +179,7 @@ public:
     uint32 GetTransmogNpcText() const;
     bool GetEnableSetInfo() const;
     uint32 GetSetNpcText() const;
+    bool GetAllowTradeable() const;
 
     bool GetUseCollectionSystem() const;
     bool GetAllowHiddenTransmog() const;

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -489,7 +489,7 @@ class PS_Transmogrification : public PlayerScript
 private:
     void AddToDatabase(Player* player, Item* item)
     {
-        if (item->HasFlag(ITEM_FIELD_FLAGS, ITEM_FIELD_FLAG_BOP_TRADEABLE) || item->HasFlag(ITEM_FIELD_FLAGS, ITEM_FIELD_FLAG_REFUNDABLE))
+        if (item->HasFlag(ITEM_FIELD_FLAGS, ITEM_FIELD_FLAG_BOP_TRADEABLE) || item->HasFlag(ITEM_FIELD_FLAGS, ITEM_FIELD_FLAG_REFUNDABLE) || AllowTradeable)
             return;
         ItemTemplate const* itemTemplate = item->GetTemplate();
         AddToDatabase(player, itemTemplate);

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -489,7 +489,9 @@ class PS_Transmogrification : public PlayerScript
 private:
     void AddToDatabase(Player* player, Item* item)
     {
-        if (item->HasFlag(ITEM_FIELD_FLAGS, ITEM_FIELD_FLAG_BOP_TRADEABLE) || item->HasFlag(ITEM_FIELD_FLAGS, ITEM_FIELD_FLAG_REFUNDABLE) || AllowTradeable)
+        if (item->HasFlag(ITEM_FIELD_FLAGS, ITEM_FIELD_FLAG_BOP_TRADEABLE) && !sTransmogrification->GetAllowTradeable())
+            return;
+        if (item->HasFlag(ITEM_FIELD_FLAGS, ITEM_FIELD_FLAG_REFUNDABLE))
             return;
         ItemTemplate const* itemTemplate = item->GetTemplate();
         AddToDatabase(player, itemTemplate);


### PR DESCRIPTION
This PR aims to address the discussion on ChromieCraft: https://github.com/chromiecraft/chromiecraft/discussions/3537

Currently the behavior is that the item doesn't get added to the appearance collection until it becomes soulbound, such as by enchanting it or running out the two hour grace period during an instance. This PR maintains that behavior by default, though I'm not sure what the alternative behavior should be, nor how to accomplish it, as I'm very unfamiliar with the way this module works.

Currently untested, but has no build errors, very open to feedback.