### PR TITLE
Implement retroactive quest appearance collection

### DIFF
--- a/conf/transmog.conf.dist
+++ b/conf/transmog.conf.dist
@@ -28,6 +28,16 @@
 #                     This allows these appearances to be used later if the configuration is changed.
 #        Default:     1
 #
+#    Transmogrification.RetroActiveAppearances
+#        Description: Enables/Disables checking all completed quests for uncollected appearances.
+#                     Occurs only once per player.
+#        Default:    1
+#
+#    Transmogrification.ResetRetroActiveAppearancesFlag
+#        Description: Resets the flag indicating whether the retroactive appearance check has been run.
+#                     Occurs for each character on log in.
+#        Default:    0
+#
 #    Transmogrification.EnableTransmogInfo
 #        Description: Enables / Disables the info button for transmogrification
 #        Default:    1
@@ -50,6 +60,8 @@ Transmogrification.Enable = 1
 Transmogrification.UseCollectionSystem = 1
 Transmogrification.AllowHiddenTransmog = 1
 Transmogrification.TrackUnusableItems = 1
+Transmogrification.RetroActiveAppearances = 1
+Transmogrification.ResetRetroActiveAppearancesFlag = 0
 
 Transmogrification.EnableTransmogInfo = 1
 Transmogrification.TransmogNpcText = 601083

--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -797,6 +797,8 @@ void Transmogrification::LoadConfig(bool reload)
     UseCollectionSystem = sConfigMgr->GetOption<bool>("Transmogrification.UseCollectionSystem", true);
     AllowHiddenTransmog = sConfigMgr->GetOption<bool>("Transmogrification.AllowHiddenTransmog", true);
     TrackUnusableItems = sConfigMgr->GetOption<bool>("Transmogrification.TrackUnusableItems", true);
+    RetroActiveAppearances = sConfigMgr->GetOption<bool>("Transmogrification.RetroActiveAppearances", true);
+    ResetRetroActiveAppearances = sConfigMgr->GetOption<bool>("Transmogrification.ResetRetroActiveAppearancesFlag", false);
 
     IsTransmogEnabled = sConfigMgr->GetOption<bool>("Transmogrification.Enable", true);
 
@@ -884,6 +886,16 @@ bool Transmogrification::GetAllowTradeable() const
 bool Transmogrification::GetTrackUnusableItems() const
 {
     return TrackUnusableItems;
+}
+
+bool Transmogrification::EnableRetroActiveAppearances() const
+{
+    return RetroActiveAppearances;
+}
+
+bool Transmogrification::EnableResetRetroActiveAppearances() const
+{
+    return ResetRetroActiveAppearances;
 }
 
 bool Transmogrification::IsEnabled() const

--- a/src/Transmogrification.h
+++ b/src/Transmogrification.h
@@ -27,6 +27,7 @@ struct ItemTemplate;
 enum TransmogSettings
 {
     SETTING_HIDE_TRANSMOG = 0,
+    SETTING_RETROACTIVE_CHECK = 1
 };
 
 enum TransmogAcoreStrings // Language.h might have same entries, appears when executing SQL, change if needed
@@ -133,6 +134,8 @@ public:
     bool UseCollectionSystem;
     bool AllowHiddenTransmog;
     bool TrackUnusableItems;
+    bool RetroActiveAppearances;
+    bool ResetRetroActiveAppearances;
 
     bool IsTransmogEnabled;
 
@@ -184,6 +187,8 @@ public:
     bool GetUseCollectionSystem() const;
     bool GetAllowHiddenTransmog() const;
     bool GetTrackUnusableItems() const;
+    bool EnableRetroActiveAppearances() const;
+    bool EnableResetRetroActiveAppearances() const;
     [[nodiscard]] bool IsEnabled() const;
 };
 #define sTransmogrification Transmogrification::instance()

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -520,7 +520,7 @@ private:
 
     void CheckRetroActiveQuestAppearances(Player* player)
     {
-        QueryResult result = CharacterDatabase.Query("SELECT `quest` FROM `character_queststatus` WHERE `status` = 3 AND `guid` = {}", player->GetGUID().GetCounter());
+        QueryResult result = CharacterDatabase.Query("SELECT `quest` FROM `character_queststatus` WHERE `status` = 1 AND `guid` = {}", player->GetGUID().GetCounter());
         if (result)
         {
             do


### PR DESCRIPTION
Added the ability to let Transmog system check for quests that were completed before transmog was added or while it was disabled, and add these rewards to the players' appearance collection. Each player is flagged after this check is run so that it will only happen once and prevent unnecessary checking; the flags can all be cleared by setting ResetRetroActiveAppearancesFlag to 1 in the config.