### PR TITLE
Correctly check rewarded quests instead of completed quests

### DIFF
--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -520,7 +520,7 @@ private:
 
     void CheckRetroActiveQuestAppearances(Player* player)
     {
-        QueryResult result = CharacterDatabase.Query("SELECT `quest` FROM `character_queststatus` WHERE `status` = 1 AND `guid` = {}", player->GetGUID().GetCounter());
+        QueryResult result = CharacterDatabase.Query("SELECT `quest` FROM `character_queststatus_rewarded` WHERE `guid` = {}", player->GetGUID().GetCounter());
         if (result)
         {
             do


### PR DESCRIPTION
This will fix the Retroactive Appearance collection check to work correctly.

Please note that the flag in mog-transmog will need to be reset for all players so that the check runs for them again.

Sorry for not catch this in my earlier testing!