### PR TITLE
Performance optimization in retroactive appearances check

### DIFF
--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -520,15 +520,11 @@ private:
 
     void CheckRetroActiveQuestAppearances(Player* player)
     {
-        QueryResult result = CharacterDatabase.Query("SELECT `quest` FROM `character_queststatus_rewarded` WHERE `guid` = {}", player->GetGUID().GetCounter());
-        if (result)
+        const RewardedQuestSet& rewQuests = GetPlayer()->getRewardedQuests();
+        for (RewardedQuestSet::const_iterator itr = rewQuests.begin(); itr != rewQuests.end(); ++itr)
         {
-            do
-            {
-                uint32 questId = (*result)[0].Get<uint32>();
-                Quest* questTemplate = const_cast<Quest*>(sObjectMgr->GetQuestTemplate(questId));
-                OnPlayerCompleteQuest(player, questTemplate);
-            } while (result->NextRow());
+            Quest const* quest = sObjectMgr->GetQuestTemplate(*itr);
+            OnPlayerCompleteQuest(player, quest);
         }
         player->UpdatePlayerSetting("mod-transmog", SETTING_RETROACTIVE_CHECK, 1);
     }

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -520,7 +520,7 @@ private:
 
     void CheckRetroActiveQuestAppearances(Player* player)
     {
-        const RewardedQuestSet& rewQuests = GetPlayer()->getRewardedQuests();
+        const RewardedQuestSet& rewQuests = player->getRewardedQuests();
         for (RewardedQuestSet::const_iterator itr = rewQuests.begin(); itr != rewQuests.end(); ++itr)
         {
             Quest const* quest = sObjectMgr->GetQuestTemplate(*itr);


### PR DESCRIPTION
Use getRewardedQuests instead of a DB call.

Thanks Nefertum for the suggestion!