### PR TITLE
Do not show Appearance Added message for items that cannot ever be transmogged

### DIFF
--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -714,6 +714,16 @@ bool Transmogrification::IsAllowedQuality(uint32 quality) const
     }
 }
 
+bool Transmogrification::CanNeverTransmog(ItemTemplate const* itemTemplate)
+{
+    return (itemTemplate->InventoryType == INVTYPE_BAG ||
+        itemTemplate->InventoryType == INVTYPE_RELIC ||
+        itemTemplate->InventoryType == INVTYPE_FINGER ||
+        itemTemplate->InventoryType == INVTYPE_TRINKET ||
+        itemTemplate->InventoryType == INVTYPE_AMMO ||
+        itemTemplate->InventoryType == INVTYPE_QUIVER);
+}
+
 void Transmogrification::LoadConfig(bool reload)
 {
 #ifdef PRESETS

--- a/src/Transmogrification.h
+++ b/src/Transmogrification.h
@@ -143,6 +143,7 @@ public:
     bool IsNotAllowed(uint32 entry) const;
     bool IsAllowedQuality(uint32 quality) const;
     bool IsRangedWeapon(uint32 Class, uint32 SubClass) const;
+    bool CanNeverTransmog(ItemTemplate const* itemTemplate);
 
     void LoadConfig(bool reload); // thread unsafe
 

--- a/src/cs_transmog.cpp
+++ b/src/cs_transmog.cpp
@@ -133,7 +133,7 @@ public:
         if (sTransmogrification->AddCollectedAppearance(accountId, itemId))
         {
             // Notify target of new item in appearance collection
-            if (target && !(target->GetPlayerSetting("mod-transmog", SETTING_HIDE_TRANSMOG).value))
+            if (target && !(target->GetPlayerSetting("mod-transmog", SETTING_HIDE_TRANSMOG).value) && !sTransmogrification->CanNeverTransmog(itemTemplate))
             {
                 ChatHandler(target->GetSession()).PSendSysMessage(R"(|c%s|Hitem:%u:0:0:0:0:0:0:0:0|h[%s]|h|r has been added to your appearance collection.)", itemQuality.c_str(), itemId, itemName.c_str());
             }

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -509,7 +509,7 @@ private:
         std::stringstream tempStream;
         tempStream << std::hex << ItemQualityColors[itemTemplate->Quality];
         std::string itemQuality = tempStream.str();
-        bool showChatMessage = !(player->GetPlayerSetting("mod-transmog", SETTING_HIDE_TRANSMOG).value);
+        bool showChatMessage = !(player->GetPlayerSetting("mod-transmog", SETTING_HIDE_TRANSMOG).value) && !sT->CanNeverTransmog(itemTemplate);
         if (sT->AddCollectedAppearance(accountId, itemId))
         {
             if (showChatMessage)


### PR DESCRIPTION
These items will continue to be add to the collection in case someone wants to remember that the player has collected these equipment, but the Appearance Collected message will never show to players because there is no appearance for these items.