### PR TITLE
Crash fix when invalid item in collection database

### DIFF
--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -423,6 +423,8 @@ public:
                         }
                     }
                     for (uint32 newItemEntryId : sT->collectionCache[accountId]) {
+                        if (!sObjectMgr->GetItemTemplate(newItemEntryId))
+                            continue;
                         Item* newItem = Item::CreateItem(newItemEntryId, 1, 0);
                         if (!newItem)
                             continue;


### PR DESCRIPTION
Avoids a crash if a player has invalid item ID stored as a collected appearance (changed or removed custom item, data corruption, etc. could cause this to happen.) Invalid item IDs are now only skipped instead.

Closes https://github.com/azerothcore/mod-transmog/issues/96