### PR TITLE
Add support for add-on sync command

### DIFF
--- a/data/sql/db-world/trasm_world_texts.sql
+++ b/data/sql/db-world/trasm_world_texts.sql
@@ -5,7 +5,7 @@ INSERT INTO `npc_text` (`ID`, `text0_0`) VALUES
 (@TEXT_ID+1, 'You can save your own transmogrification sets.\r\n\r\nTo save, first you must transmogrify your equipped items.\r\nThen when you go to the set management menu and go to save set menu,\r\nall items you have transmogrified are displayed so you see what you are saving.\r\nIf you think the set is fine, you can click to save the set and name it as you wish.\r\n\r\nTo use a set you can click the saved set in the set management menu and then select use set.\r\nIf the set has a transmogrification for an item that is already transmogrified, the old transmogrification is lost.\r\nNote that same transmogrification restrictions apply when trying to use a set as in normal transmogrification.\r\n\r\nTo delete a set you can go to the set\'s menu and select delete set.');
 
 SET @STRING_ENTRY := 11100;
-DELETE FROM `acore_string` WHERE `entry` IN  (@STRING_ENTRY+0,@STRING_ENTRY+1,@STRING_ENTRY+2,@STRING_ENTRY+3,@STRING_ENTRY+4,@STRING_ENTRY+5,@STRING_ENTRY+6,@STRING_ENTRY+7,@STRING_ENTRY+8,@STRING_ENTRY+9,@STRING_ENTRY+10, @STRING_ENTRY+11, @STRING_ENTRY+12, @STRING_ENTRY+13, @STRING_ENTRY+14);
+DELETE FROM `acore_string` WHERE `entry` IN  (@STRING_ENTRY+0,@STRING_ENTRY+1,@STRING_ENTRY+2,@STRING_ENTRY+3,@STRING_ENTRY+4,@STRING_ENTRY+5,@STRING_ENTRY+6,@STRING_ENTRY+7,@STRING_ENTRY+8,@STRING_ENTRY+9,@STRING_ENTRY+10, @STRING_ENTRY+11, @STRING_ENTRY+12, @STRING_ENTRY+13, @STRING_ENTRY+14, @STRING_ENTRY+15, @STRING_ENTRY+16);
 INSERT INTO `acore_string` (`entry`, `content_default`) VALUES
 (@STRING_ENTRY+0, 'Item successfully transmogrified.'),
 (@STRING_ENTRY+1, 'Equipment slot is empty.'),
@@ -21,10 +21,13 @@ INSERT INTO `acore_string` (`entry`, `content_default`) VALUES
 (@STRING_ENTRY+11, 'Showing transmogrifieded items, relog to update the current area.'),
 (@STRING_ENTRY+12, 'Hiding transmogrifieded items, relog to update the current area.'),
 (@STRING_ENTRY+13, 'The selected Item is not suitable for transmogrification.'),
-(@STRING_ENTRY+14, 'The selected Item cannot be used for transmogrification of the target player.');
+(@STRING_ENTRY+14, 'The selected Item cannot be used for transmogrification of the target player.'),
+(@STRING_ENTRY+15, 'Performing transmog appearance sync....'),
+(@STRING_ENTRY+16, 'Appearance sync complete.');
 
 DELETE FROM `command` WHERE `name` IN ('transmog', 'transmog add', 'transmog add set');
 INSERT INTO `command` (`name`, `security`, `help`) VALUES
 ('transmog', 0, 'Syntax: .transmog <on/off>\nAllows seeing transmogrified items and the transmogrifier NPC.'),
 ('transmog add', 1, 'Syntax: .transmog add $player $item\nAdds an item to a player\'s appearance collection.'),
+('transmog sync', 1, 'Syntax: .transmog sync\nSyncs transmog addon appearances with the server.'),
 ('transmog add set', 1, 'Syntax: .transmog add set $player $itemSet\nAdds items of an ItemSet to a player\'s appearance collection.');

--- a/src/Transmogrification.h
+++ b/src/Transmogrification.h
@@ -52,6 +52,8 @@ enum TransmogAcoreStrings // Language.h might have same entries, appears when ex
     LANG_CMD_TRANSMOG_HIDE = 11112,
     LANG_CMD_TRANSMOG_ADD_UNSUITABLE = 11113,
     LANG_CMD_TRANSMOG_ADD_FORBIDDEN = 11114,
+    LANG_CMD_TRANSMOG_BEGIN_SYNC = 11115,
+    LANG_CMD_TRANSMOG_COMPLETE_SYNC = 11116,
 };
 
 class Transmogrification

--- a/src/cs_transmog.cpp
+++ b/src/cs_transmog.cpp
@@ -40,7 +40,8 @@ public:
         static ChatCommandTable transmogTable =
         {
             { "add", addCollectionTable },
-            { "",    HandleDisableTransMogVisual, SEC_PLAYER,    Console::No },
+            { "",    HandleDisableTransMogVisual,   SEC_PLAYER,    Console::No },
+            { "sync",    HandleSyncTransMogCommand, SEC_PLAYER,    Console::No },
         };
 
         static ChatCommandTable commandTable =
@@ -49,6 +50,19 @@ public:
         };
 
         return commandTable;
+    }
+
+    static bool HandleSyncTransMogCommand(ChatHandler* handler, char const* /*args*/)
+    {
+        Player* player = handler->GetPlayer();
+        uint32 accountId = player->GetSession()->GetAccountId();
+        handler->SendSysMessage(LANG_CMD_TRANSMOG_BEGIN_SYNC);
+        for (uint32 itemId : sTransmogrification->collectionCache[accountId])
+        {
+            handler->PSendSysMessage("TRANSMOG_SYNC:%u", itemId);
+        }
+        handler->SendSysMessage(LANG_CMD_TRANSMOG_COMPLETE_SYNC);
+        return true;
     }
 
     static bool HandleDisableTransMogVisual(ChatHandler* handler, bool hide)


### PR DESCRIPTION
This allows the latest version of https://github.com/ZhengPeiRu21/transmog-addons to sync appearances with the server when the command is run. This also could be useful for any other addon that would like to track collected appearances, so it is not only used by this addon.