### PR TITLE
Fix crash when performing RetroActive appearance check with invalid quest IDs

### DIFF
--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -609,7 +609,7 @@ public:
 
     void OnPlayerCompleteQuest(Player* player, Quest const* quest) override
     {
-        if (!sT->GetUseCollectionSystem())
+        if (!sT->GetUseCollectionSystem() || !quest)
             return;
         for (uint8 i = 0; i < QUEST_REWARD_CHOICES_COUNT; ++i)
         {


### PR DESCRIPTION
Closes https://github.com/azerothcore/mod-transmog/issues/100.