### PR TITLE
feat: Implement multiple AllowMixedWeaponType options

### DIFF
--- a/conf/transmog.conf.dist
+++ b/conf/transmog.conf.dist
@@ -149,7 +149,10 @@ Transmogrification.TokenAmount = 1
 #
 #    Transmogrification.AllowMixedWeaponTypes
 #        Description: Allow axe to be transmogrified with dagger for example
-#        Default:    0
+#        Possible options:
+#            Default:    0 - STRICT - Fully restricted like original Blizzard 4.3 transmog - Weapons must be the same weapon type (exceptions: Guns, Crossbows, or Bows)
+#                        1 - MODERN - Like later retail WoW, allow swords to be transmogged to axes, etc.
+#                        2 - FULL - No restrictions, allow any weapon to be transmogrified to any other weapon
 #
 #    Transmogrification.AllowFishingPoles
 #        Description: Allow fishing poles to be transmogrified

--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -476,7 +476,7 @@ bool Transmogrification::CanTransmogrifyItemWithItem(Player* player, ItemTemplat
                 {
                     return false;
                 }
-                else if (AllowMixedWeaponTypes == MIXED_WEAPONS_MODERN)
+                if (AllowMixedWeaponTypes == MIXED_WEAPONS_MODERN)
                 {
                     switch (source->SubClass)
                     {
@@ -852,7 +852,7 @@ void Transmogrification::LoadConfig(bool reload)
     AllowMixedArmorTypes = sConfigMgr->GetOption<bool>("Transmogrification.AllowMixedArmorTypes", false);
     AllowFishingPoles = sConfigMgr->GetOption<bool>("Transmogrification.AllowFishingPoles", false);
 
-    AllowMixedWeaponTypes = sConfigMgr->GetOption<uint8>("Transmogrification.AllowMixedWeaponTypes", 0);
+    AllowMixedWeaponTypes = sConfigMgr->GetOption<uint8>("Transmogrification.AllowMixedWeaponTypes", MIXED_WEAPONS_STRICT);
 
     IgnoreReqRace = sConfigMgr->GetOption<bool>("Transmogrification.IgnoreReqRace", false);
     IgnoreReqClass = sConfigMgr->GetOption<bool>("Transmogrification.IgnoreReqClass", false);

--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -477,6 +477,14 @@ bool Transmogrification::CanTransmogrifyItemWithItem(Player* player, ItemTemplat
 
     if (source->InventoryType != target->InventoryType)
     {
+
+        // Main-hand to offhand restrictions - see https://wowpedia.fandom.com/wiki/Transmogrification
+        if ((source->InventoryType == INVTYPE_WEAPONMAINHAND && target->InventoryType != INVTYPE_WEAPONMAINHAND)
+            || (source->InventoryType == INVTYPE_WEAPONOFFHAND && target->InventoryType != INVTYPE_WEAPONOFFHAND))
+        {
+            return false;
+        }
+
         if (source->Class == ITEM_CLASS_WEAPON && !(IsRangedWeapon(target->Class, target->SubClass) ||
             (
                 // [AZTH] Yehonal: fixed weapon check

--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -485,14 +485,22 @@ bool Transmogrification::CanTransmogrifyItemWithItem(Player* player, ItemTemplat
                         case ITEM_SUBCLASS_WEAPON_FIST:
                             return false;
                         case ITEM_SUBCLASS_WEAPON_AXE:
+                        case ITEM_SUBCLASS_WEAPON_SWORD:
+                        case ITEM_SUBCLASS_WEAPON_MACE:
                             if (target->SubClass != ITEM_SUBCLASS_WEAPON_MACE &&
+                                target->SubClass != ITEM_SUBCLASS_WEAPON_AXE &&
                                 target->SubClass != ITEM_SUBCLASS_WEAPON_SWORD)
                             {
                                 return false;
                             }
                             break;
                         case ITEM_SUBCLASS_WEAPON_AXE2:
+                        case ITEM_SUBCLASS_WEAPON_SWORD2:
+                        case ITEM_SUBCLASS_WEAPON_MACE2:
+                        case ITEM_SUBCLASS_WEAPON_STAFF:
+                        case ITEM_SUBCLASS_WEAPON_POLEARM:
                             if (target->SubClass != ITEM_SUBCLASS_WEAPON_MACE2 &&
+                                target->SubClass != ITEM_SUBCLASS_WEAPON_AXE2 &&
                                 target->SubClass != ITEM_SUBCLASS_WEAPON_SWORD2 &&
                                 target->SubClass != ITEM_SUBCLASS_WEAPON_STAFF &&
                                 target->SubClass != ITEM_SUBCLASS_WEAPON_POLEARM)

--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -470,8 +470,41 @@ bool Transmogrification::CanTransmogrifyItemWithItem(Player* player, ItemTemplat
         {
             if (source->Class == ITEM_CLASS_ARMOR && !AllowMixedArmorTypes)
                 return false;
-            if (source->Class == ITEM_CLASS_WEAPON && !AllowMixedWeaponTypes)
-                return false;
+            if (source->Class == ITEM_CLASS_WEAPON)
+            {
+                if (AllowMixedWeaponTypes == MIXED_WEAPONS_STRICT)
+                {
+                    return false;
+                }
+                else if (AllowMixedWeaponTypes == MIXED_WEAPONS_MODERN)
+                {
+                    switch (source->SubClass)
+                    {
+                        case ITEM_SUBCLASS_WEAPON_WAND:
+                        case ITEM_SUBCLASS_WEAPON_DAGGER:
+                        case ITEM_SUBCLASS_WEAPON_FIST:
+                            return false;
+                        case ITEM_SUBCLASS_WEAPON_AXE:
+                            if (target->SubClass != ITEM_SUBCLASS_WEAPON_MACE &&
+                                target->SubClass != ITEM_SUBCLASS_WEAPON_SWORD)
+                            {
+                                return false;
+                            }
+                            break;
+                        case ITEM_SUBCLASS_WEAPON_AXE2:
+                            if (target->SubClass != ITEM_SUBCLASS_WEAPON_MACE2 &&
+                                target->SubClass != ITEM_SUBCLASS_WEAPON_SWORD2 &&
+                                target->SubClass != ITEM_SUBCLASS_WEAPON_STAFF &&
+                                target->SubClass != ITEM_SUBCLASS_WEAPON_POLEARM)
+                            {
+                                return false;
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
         }
     }
 
@@ -479,7 +512,7 @@ bool Transmogrification::CanTransmogrifyItemWithItem(Player* player, ItemTemplat
     {
 
         // Main-hand to offhand restrictions - see https://wowpedia.fandom.com/wiki/Transmogrification
-        if (!AllowMixedWeaponTypes && ((source->InventoryType == INVTYPE_WEAPONMAINHAND && target->InventoryType != INVTYPE_WEAPONMAINHAND)
+        if (AllowMixedWeaponTypes != MIXED_WEAPONS_LOOSE && ((source->InventoryType == INVTYPE_WEAPONMAINHAND && target->InventoryType != INVTYPE_WEAPONMAINHAND)
             || (source->InventoryType == INVTYPE_WEAPONOFFHAND && target->InventoryType != INVTYPE_WEAPONOFFHAND)))
         {
             return false;
@@ -527,7 +560,7 @@ bool Transmogrification::SuitableForTransmogrification(Player* player, ItemTempl
             return false;
         }
 
-        if (proto->Class == ITEM_CLASS_WEAPON && !AllowMixedWeaponTypes)
+        if (proto->Class == ITEM_CLASS_WEAPON && AllowMixedWeaponTypes != MIXED_WEAPONS_LOOSE)
         {
             return false;
         }
@@ -809,8 +842,9 @@ void Transmogrification::LoadConfig(bool reload)
     AllowTradeable = sConfigMgr->GetOption<bool>("Transmogrification.AllowTradeable", false);
 
     AllowMixedArmorTypes = sConfigMgr->GetOption<bool>("Transmogrification.AllowMixedArmorTypes", false);
-    AllowMixedWeaponTypes = sConfigMgr->GetOption<bool>("Transmogrification.AllowMixedWeaponTypes", false);
     AllowFishingPoles = sConfigMgr->GetOption<bool>("Transmogrification.AllowFishingPoles", false);
+
+    AllowMixedWeaponTypes = sConfigMgr->GetOption<uint8>("Transmogrification.AllowMixedWeaponTypes", 0);
 
     IgnoreReqRace = sConfigMgr->GetOption<bool>("Transmogrification.IgnoreReqRace", false);
     IgnoreReqClass = sConfigMgr->GetOption<bool>("Transmogrification.IgnoreReqClass", false);
@@ -889,7 +923,7 @@ bool Transmogrification::GetAllowMixedArmorTypes() const
 {
     return AllowMixedArmorTypes;
 };
-bool Transmogrification::GetAllowMixedWeaponTypes() const
+uint8 Transmogrification::GetAllowMixedWeaponTypes() const
 {
     return AllowMixedWeaponTypes;
 };

--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -479,8 +479,8 @@ bool Transmogrification::CanTransmogrifyItemWithItem(Player* player, ItemTemplat
     {
 
         // Main-hand to offhand restrictions - see https://wowpedia.fandom.com/wiki/Transmogrification
-        if ((source->InventoryType == INVTYPE_WEAPONMAINHAND && target->InventoryType != INVTYPE_WEAPONMAINHAND)
-            || (source->InventoryType == INVTYPE_WEAPONOFFHAND && target->InventoryType != INVTYPE_WEAPONOFFHAND))
+        if (!AllowMixedWeaponTypes && ((source->InventoryType == INVTYPE_WEAPONMAINHAND && target->InventoryType != INVTYPE_WEAPONMAINHAND)
+            || (source->InventoryType == INVTYPE_WEAPONOFFHAND && target->InventoryType != INVTYPE_WEAPONOFFHAND)))
         {
             return false;
         }

--- a/src/Transmogrification.h
+++ b/src/Transmogrification.h
@@ -31,6 +31,13 @@ enum TransmogSettings
     SETTING_RETROACTIVE_CHECK = 1
 };
 
+enum MixedWeaponSettings
+{
+    MIXED_WEAPONS_STRICT = 0,
+    MIXED_WEAPONS_MODERN = 1,
+    MIXED_WEAPONS_LOOSE  = 2
+};
+
 enum TransmogAcoreStrings // Language.h might have same entries, appears when executing SQL, change if needed
 {
     LANG_ERR_TRANSMOG_OK = 11100, // change this
@@ -125,8 +132,9 @@ public:
     bool AllowTradeable;
 
     bool AllowMixedArmorTypes;
-    bool AllowMixedWeaponTypes;
     bool AllowFishingPoles;
+
+    uint8 AllowMixedWeaponTypes;
 
     bool IgnoreReqRace;
     bool IgnoreReqClass;
@@ -181,7 +189,7 @@ public:
     uint32 GetTokenAmount() const;
 
     bool GetAllowMixedArmorTypes() const;
-    bool GetAllowMixedWeaponTypes() const;
+    uint8 GetAllowMixedWeaponTypes() const;
 
     // Config
     bool GetEnableTransmogInfo() const;


### PR DESCRIPTION
Correctly do allow Main-hand Weapons and Off-hand Weapons to only be allowed to transmog to weapons of the same inventory type.