### PR TITLE
(bug) Adds check to OnLootItem() to ensure that the pointer is still valid

### DIFF
--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -582,7 +582,7 @@ public:
 
     void OnLootItem(Player* player, Item* item, uint32 /*count*/, ObjectGuid /*lootguid*/) override
     {
-        if (!sT->GetUseCollectionSystem() || !item)
+        if (!sT->GetUseCollectionSystem() || !item || typeid(*item) != typeid(Item))
             return;
         if (item->GetTemplate()->Bonding == ItemBondingType::BIND_WHEN_PICKED_UP || item->IsSoulBound())
         {


### PR DESCRIPTION
Found this bug when testing out a new module: https://github.com/noisiver/mod-junk-to-gold

`junk-to-gold` also uses the `OnLootItem` function and was being called BEFORE `transmog`. By the time `transmog` gets to the item, the item is already gone.

This type check ensures that the pointer still points to an item. If not, it must have been deleted by `junk-to-gold` or any other module that might delete an item when `OnLootItem` is triggered.

I am unsure if `!item` is still needed or not. It appears that it passes even when the pointer doesn't point to anything useful.