### PR TITLE
fix: add null-check for target var in transmog_scripts.cpp

### DIFF
--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -364,7 +364,7 @@ public:
                 }
             }
 
-            return sTransmogrification->IsEnabled() && !target->GetPlayerSetting("mod-transmog", SETTING_HIDE_TRANSMOG).value;
+            return sTransmogrification->IsEnabled() && (target && !target->GetPlayerSetting("mod-transmog", SETTING_HIDE_TRANSMOG).value);
         }
     };
 


### PR DESCRIPTION
checking this crash log https://gist.github.com/assada/068435b470644a1b9a98d94b61a056d3
it seems that the `target` variable is `0x0` as value, this could make the crash but I am not sure 100%, so please, test this PR.

closes https://github.com/azerothcore/mod-transmog/issues/112
closes https://github.com/azerothcore/mod-transmog/issues/135