### PR TITLE
Use new unit hooks to optimize BuildValuesUpdate

### DIFF
--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -1118,21 +1118,26 @@ class unit_transmog_script : public UnitScript
 public:
     unit_transmog_script() : UnitScript("unit_transmog_script") { }
 
-    bool OnBuildValuesUpdate(Unit const* unit, uint8 /*updateType*/, ByteBuffer& fieldBuffer, Player* target, uint16 index) override
+    bool ShouldTrackValuesUpdatePosByIndex(Unit const* unit, uint8 updateType, uint16 index) override
     {
         if (unit->IsPlayer() && index >= PLAYER_VISIBLE_ITEM_1_ENTRYID && index <= PLAYER_VISIBLE_ITEM_19_ENTRYID && (index & 1))
-        {
-            if (Item* item = unit->ToPlayer()->GetItemByPos(INVENTORY_SLOT_BAG_0, ((index - PLAYER_VISIBLE_ITEM_1_ENTRYID) / 2U)))
-            {
-                if (!sTransmogrification->IsEnabled() || target->GetPlayerSetting("mod-transmog", SETTING_HIDE_TRANSMOG).value)
-                {
-                    fieldBuffer << item->GetEntry();
-                    return true;
-                }
-            }
-        }
-
+            return true;
         return false;
+    }
+
+    void OnPatchValuesUpdate(Unit const* unit, ByteBuffer& valuesUpdateBuf, BuildValuesCachePosPointers& posPointers, Player* target) override
+    {
+        if (!unit->IsPlayer())
+            return;
+
+        for (auto it = posPointers.other.begin(); it != posPointers.other.end(); ++it)
+        {
+            uint16 index = it->first;
+            if (index >= PLAYER_VISIBLE_ITEM_1_ENTRYID && index <= PLAYER_VISIBLE_ITEM_19_ENTRYID && (index & 1))
+                if (Item* item = unit->ToPlayer()->GetItemByPos(INVENTORY_SLOT_BAG_0, ((index - PLAYER_VISIBLE_ITEM_1_ENTRYID) / 2U)))
+                    if (!sTransmogrification->IsEnabled() || target->GetPlayerSetting("mod-transmog", SETTING_HIDE_TRANSMOG).value)
+                        valuesUpdateBuf.put(it->second, item->GetEntry());
+        }
     }
 };
 

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -1118,7 +1118,7 @@ class unit_transmog_script : public UnitScript
 public:
     unit_transmog_script() : UnitScript("unit_transmog_script") { }
 
-    bool ShouldTrackValuesUpdatePosByIndex(Unit const* unit, uint8 updateType, uint16 index) override
+    bool ShouldTrackValuesUpdatePosByIndex(Unit const* unit, uint8 /*updateType*/, uint16 index) override
     {
         if (unit->IsPlayer() && index >= PLAYER_VISIBLE_ITEM_1_ENTRYID && index <= PLAYER_VISIBLE_ITEM_19_ENTRYID && (index & 1))
             return true;

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -1120,9 +1120,7 @@ public:
 
     bool ShouldTrackValuesUpdatePosByIndex(Unit const* unit, uint8 /*updateType*/, uint16 index) override
     {
-        if (unit->IsPlayer() && index >= PLAYER_VISIBLE_ITEM_1_ENTRYID && index <= PLAYER_VISIBLE_ITEM_19_ENTRYID && (index & 1))
-            return true;
-        return false;
+        return unit->IsPlayer() && index >= PLAYER_VISIBLE_ITEM_1_ENTRYID && index <= PLAYER_VISIBLE_ITEM_19_ENTRYID && (index & 1);
     }
 
     void OnPatchValuesUpdate(Unit const* unit, ByteBuffer& valuesUpdateBuf, BuildValuesCachePosPointers& posPointers, Player* target) override


### PR DESCRIPTION
This PR uses the new hooks introduced here - https://github.com/azerothcore/azerothcore-wotlk/pull/18637.