### PR TITLE
Fixed a bug with One-Hand transmogging

### DIFF
--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -717,6 +717,12 @@ bool Transmogrification::IsInvTypeMismatchAllowed(const ItemTemplate *source, co
                 return true;
             if (sourceType == INVTYPE_WEAPONMAINHAND || sourceType == INVTYPE_WEAPONOFFHAND)
                 return (AllowMixedWeaponHandedness || AllowMixedWeaponTypes == MIXED_WEAPONS_LOOSE);
+            if (sourceType == INVTYPE_WEAPON)
+                return true;
+        }
+        else if (targetType == INVTYPE_WEAPON)
+        {
+            return sourceType == INVTYPE_WEAPONMAINHAND || (AllowMixedWeaponTypes == MIXED_WEAPONS_LOOSE && sourceType == INVTYPE_WEAPONOFFHAND);
         }
     }
     else if (targetClass == ITEM_CLASS_ARMOR)


### PR DESCRIPTION
I somehow missed in my previous MR that an exception was missing for One-Hand -> Main Hand/Main Hand -> One-Hand etc. 

This MR allows One Hand (handedness agnostic) weapons to be transmogged by Main Hand weapons (and Off-Hand weapons if LOOSE mixed weapon type), and Main Hand/Off Hand weapons to be transmogged by One Hand weapons.

Fixes #159 