### PR TITLE
Improve eligibility checks for portable transmog NPC

### DIFF
--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -1229,6 +1229,9 @@ bool Transmogrification::IsPlusFeatureEligible(ObjectGuid const &playerGuid, uin
     if (!player)
         return false;
 
+    if (player->IsGameMaster())
+        return true; // GM can use all features
+
     const auto membershipLevel = GetPlayerMembershipLevel(player);
 
     if (!membershipLevel)


### PR DESCRIPTION
Added Game Master override for plus feature eligibility and enhanced error handling in the portable transmogrification NPC command. Now checks for feature enablement, player eligibility, and spell availability before casting.