### PR TITLE
fix crash when mod-transmog is used alongside playerbot and junk-to-gold

### DIFF
--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -1064,21 +1064,22 @@ public:
         AddToDatabase(player, it);
     }
 
-    void OnPlayerLootItem(Player* player, Item* item, uint32 /*count*/, ObjectGuid /*lootguid*/) override
+    void OnPlayerLootItem(Player* /*player*/, Item* /*item*/, uint32 /*count*/, ObjectGuid /*lootguid*/) override
     {
-        if (!sT->GetUseCollectionSystem() || !item || typeid(*item) != typeid(Item))
-            return;
-        if (item->GetTemplate()->Bonding == ItemBondingType::BIND_WHEN_PICKED_UP || item->IsSoulBound())
-        {
-            AddToDatabase(player, item);
-        }
+        // Intentionally left no-op. Other modules (e.g., auto-destroy/sell junk) may delete the item
+        // during earlier OnPlayerLootItem hooks, making this pointer unsafe to touch.
+        // Collection is handled in OnPlayerCreateItem and OnPlayerAfterStoreOrEquipNewItem.
+        return;
     }
 
     void OnPlayerCreateItem(Player* player, Item* item, uint32 /*count*/) override
     {
-        if (!sT->GetUseCollectionSystem())
+        if (!sT->GetUseCollectionSystem() || !item)
             return;
-        if (item->GetTemplate()->Bonding == ItemBondingType::BIND_WHEN_PICKED_UP || item->IsSoulBound())
+        ItemTemplate const* itemTemplate = item->GetTemplate();
+        if (!itemTemplate)
+            return;
+        if (itemTemplate->Bonding == ItemBondingType::BIND_WHEN_PICKED_UP || item->IsSoulBound())
         {
             AddToDatabase(player, item);
         }
@@ -1086,9 +1087,12 @@ public:
 
     void OnPlayerAfterStoreOrEquipNewItem(Player* player, uint32 /*vendorslot*/, Item* item, uint8 /*count*/, uint8 /*bag*/, uint8 /*slot*/, ItemTemplate const* /*pProto*/, Creature* /*pVendor*/, VendorItem const* /*crItem*/, bool /*bStore*/) override
     {
-        if (!sT->GetUseCollectionSystem())
+        if (!sT->GetUseCollectionSystem() || !item)
             return;
-        if (item->GetTemplate()->Bonding == ItemBondingType::BIND_WHEN_PICKED_UP || item->IsSoulBound())
+        ItemTemplate const* itemTemplate = item->GetTemplate();
+        if (!itemTemplate)
+            return;
+        if (itemTemplate->Bonding == ItemBondingType::BIND_WHEN_PICKED_UP || item->IsSoulBound())
         {
             AddToDatabase(player, item);
         }


### PR DESCRIPTION
I'm running the worldserver with mod-playerbots and mod-junk-to-gold activated.

After I installed mod-transmog, my world server kept crashing right after launch and after the first playerbots started logging in. Investigation went as follows:
- A playerbot looted something -> segfault on [typeid()](https://github.com/azerothcore/mod-transmog/blob/master/src/transmog_scripts.cpp#L1069).


<details>

<summary>First crash, before removing typeid() check</summary>


```bash
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0xfffffffffffffff8)
  * frame #0: 0x0000000100b34d10 worldserver`PS_Transmogrification::OnPlayerLootItem(this=0x0000600000104900, player=0x000000029e335800, item=0x00000002cfebfd50, (null)=1, (null)=(_guid = 17379391320803514991)) at transmog_scripts.cpp:1069:55
    frame #1: 0x0000000102dc6b14 worldserver`ScriptMgr::OnPlayerLootItem(this=0x00000001040c99f8, player=0x000000029e335800, item=0x00000002cfebfd50, count=1, lootguid=(_guid = 17379391320803514991)) at PlayerScript.cpp:380:5
    frame #2: 0x0000000102490430 worldserver`Player::StoreLootItem(this=0x000000029e335800, lootSlot='\0', loot=0x000000029e6e4840, msg=0x000000016fdfc1c7) at Player.cpp:13673:21
    frame #3: 0x00000001029928d8 worldserver`WorldSession::HandleAutostoreLootItemOpcode(this=0x0000000160c9cf90, recvData=0x0000600011374640) at LootHandler.cpp:99:34
    frame #4: 0x0000000102ff2c70 worldserver`PacketHandler<WorldPacket, &WorldSession::HandleAutostoreLootItemOpcode(WorldPacket&)>::Call(this=0x000060000caca9c0, session=0x0000000160c9cf90, packet=0x0000600011374640) const at Opcodes.cpp:47:9
    frame #5: 0x000000010019b964 worldserver`PlayerbotHolder::HandleBotPackets(this=0x000000010405f770, session=0x0000000160c9cf90) at PlayerbotMgr.cpp:236:19
    frame #6: 0x000000010019b290 worldserver`PlayerbotHolder::UpdateSessions(this=0x000000010405f770) at PlayerbotMgr.cpp:218:13
    frame #7: 0x00000001001d0e90 worldserver`PlayerbotsScript::OnPlayerbotUpdate(this=0x0000600000104690, diff=13) at Playerbots.cpp:394:30
    frame #8: 0x0000000102ddd9dc worldserver`ScriptMgr::OnPlayerbotUpdate(unsigned int)::$_5::operator()(this=0x000000016fdfc9c0, script=0x0000600000104690) const at PlayerbotsScript.cpp:79:17
    frame #9: 0x0000000102ddd9a0 worldserver`decltype(std::declval<ScriptMgr::OnPlayerbotUpdate(unsigned int)::$_5&>()(std::declval<PlayerbotScript*>())) std::__1::__invoke[abi:ue170006]<ScriptMgr::OnPlayerbotUpdate(unsigned int)::$_5&, PlayerbotScript*>(__f=0x000000016fdfc9c0, __args=0x000000016fdfc900) at invoke.h:340:25
    frame #10: 0x0000000102ddd94c worldserver`void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ue170006]<ScriptMgr::OnPlayerbotUpdate(unsigned int)::$_5&, PlayerbotScript*>(__args=0x000000016fdfc9c0, __args=0x000000016fdfc900) at invoke.h:415:5
    frame #11: 0x0000000102ddd920 worldserver`std::__1::__function::__alloc_func<ScriptMgr::OnPlayerbotUpdate(unsigned int)::$_5, std::__1::allocator<ScriptMgr::OnPlayerbotUpdate(unsigned int)::$_5>, void (PlayerbotScript*)>::operator()[abi:ue170006](this=0x000000016fdfc9c0, __arg=0x000000016fdfc900) at function.h:193:16
    frame #12: 0x0000000102ddc79c worldserver`std::__1::__function::__func<ScriptMgr::OnPlayerbotUpdate(unsigned int)::$_5, std::__1::allocator<ScriptMgr::OnPlayerbotUpdate(unsigned int)::$_5>, void (PlayerbotScript*)>::operator()(this=0x000000016fdfc9b8, __arg=0x000000016fdfc900) at function.h:364:12
    frame #13: 0x0000000102dd5e44 worldserver`std::__1::__function::__value_func<void (PlayerbotScript*)>::operator()[abi:ue170006](this=0x000000016fdfc9b8, __args=0x000000016fdfc900) const at function.h:518:16
    frame #14: 0x0000000102dd5dec worldserver`std::__1::function<void (PlayerbotScript*)>::operator()(this= Lambda in File PlayerbotsScript.cpp at Line 78, __arg=0x0000600000104690) const at function.h:1169:12
    frame #15: 0x0000000102dd3c0c worldserver`void ExecuteScript<PlayerbotScript>(executeHook= Lambda in File PlayerbotsScript.cpp at Line 78) at ScriptMgrMacros.h:63:9
    frame #16: 0x0000000102dd3ff0 worldserver`ScriptMgr::OnPlayerbotUpdate(this=0x00000001040c99f8, diff=13) at PlayerbotsScript.cpp:77:5
    frame #17: 0x000000010321d584 worldserver`World::Update(this=0x000000013d0e3750, diff=13) at World.cpp:1172:17
    frame #18: 0x0000000100011294 worldserver`WorldUpdateLoop() at Main.cpp:596:17
    frame #19: 0x000000010000bcfc worldserver`main(argc=1, argv=0x000000016fdff288) at Main.cpp:399:5
    frame #20: 0x00000001879290e0 dyld`start + 2360
```

</details>

I removed that check.

- Then I hit a new segfault afterwards when I started looting gray items myself, probably the one https://github.com/azerothcore/mod-transmog/pull/123 was fixing


<details>
<summary>Second crash, after removing typeid() check</summary>

```bash
* thread #9, stop reason = EXC_BAD_ACCESS (code=1, address=0x78)
  * frame #0: 0x00000001023e4a40 worldserver`Object::GetUInt32Value(this=0x000000032e6e39d0, index=3) const at Object.cpp:296:5
    frame #1: 0x00000001000b69a8 worldserver`Object::GetEntry(this=0x000000032e6e39d0) const at Object.h:116:52
    frame #2: 0x00000001023cb484 worldserver`Item::GetTemplate(this=0x000000032e6e39d0) const at Item.cpp:546:40
    frame #3: 0x0000000100b34cb8 worldserver`PS_Transmogrification::OnPlayerLootItem(this=0x00006000015e23d0, player=0x000000033ec98200, item=0x000000032e6e39d0, (null)=1, (null)=(_guid = 17379391218277952867)) at transmog_scripts.cpp:1071:50
    frame #4: 0x0000000102dc6b20 worldserver`ScriptMgr::OnPlayerLootItem(this=0x00000001040c99f8, player=0x000000033ec98200, item=0x000000032e6e39d0, count=1, lootguid=(_guid = 17379391218277952867)) at PlayerScript.cpp:380:5
    frame #5: 0x000000010249043c worldserver`Player::StoreLootItem(this=0x000000033ec98200, lootSlot='\0', loot=0x00000002f00b2640, msg=0x0000000170258dd7) at Player.cpp:13673:21
    frame #6: 0x00000001029928e4 worldserver`WorldSession::HandleAutostoreLootItemOpcode(this=0x0000000310b1fc10, recvData=0x0000600014e8ac40) at LootHandler.cpp:99:34
    frame #7: 0x0000000102ff2c7c worldserver`PacketHandler<WorldPacket, &WorldSession::HandleAutostoreLootItemOpcode(WorldPacket&)>::Call(this=0x000060000decaf20, session=0x0000000310b1fc10, packet=0x0000600014e8ac40) const at Opcodes.cpp:47:9
    frame #8: 0x0000000102e28de4 worldserver`WorldSession::Update(this=0x0000000310b1fc10, diff=5, updater=0x000000017025ad40) at WorldSession.cpp:415:35
    frame #9: 0x0000000102a98a68 worldserver`Map::Update(this=0x0000000130080000, t_diff=114, s_diff=5, (null)=true) at Map.cpp:442:22
    frame #10: 0x0000000102adcef8 worldserver`MapUpdateRequest::call(this=0x0000600029fcab60) at MapUpdater.cpp:46:15
    frame #11: 0x0000000102adc0d8 worldserver`MapUpdater::WorkerThread(this=0x00000001040c8dc0) at MapUpdater.cpp:186:22
    frame #12: 0x0000000102ade194 worldserver`decltype(*std::declval<MapUpdater*>().*std::declval<void (MapUpdater::*)()>()()) std::__1::__invoke[abi:ue170006]<void (MapUpdater::*)(), MapUpdater*, void>(__f=0x000060000dec8fa8, __a0=0x000060000dec8fb8) at invoke.h:308:25
    frame #13: 0x0000000102ade114 worldserver`void std::__1::__thread_execute[abi:ue170006]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (MapUpdater::*)(), MapUpdater*, 2ul>(__t=size=3, (null)=__tuple_indices<2UL> @ 0x000000017025af7f) at thread.h:227:5
    frame #14: 0x0000000102adddc0 worldserver`void* std::__1::__thread_proxy[abi:ue170006]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (MapUpdater::*)(), MapUpdater*>>(__vp=0x000060000dec8fa0) at thread.h:238:5
    frame #15: 0x0000000187ca5034 libsystem_pthread.dylib`_pthread_start + 136
```
</details>

I ended up removing the whole body of `OnPlayerLootItem` as it seems other hooks are handling all needed cases, but I don't have much knowledge on the codebase so I could be wrong. That said I played with 500 bots, looted many mobs and witnessed bots loot too, no more crash.

I'll do some more tests but opening the PR now in case you have early feedback

Thanks
