### PR TITLE
Add retroactive inventory and bank appearance backfill

### DIFF
--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -1033,14 +1033,70 @@ private:
         }
     }
 
+    void CheckRetroActiveInventoryAppearances(Player* player)
+    {
+        if (!sT->GetUseCollectionSystem())
+            return;
+
+        for (uint8 slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END; ++slot)
+        {
+            if (Item* item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
+                AddToDatabase(player, item);
+        }
+
+        for (uint8 slot = INVENTORY_SLOT_ITEM_START; slot < INVENTORY_SLOT_ITEM_END; ++slot)
+        {
+            if (Item* item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
+                AddToDatabase(player, item);
+        }
+
+        for (uint8 bagPos = INVENTORY_SLOT_BAG_START; bagPos < INVENTORY_SLOT_BAG_END; ++bagPos)
+        {
+            Bag* bag = player->GetBagByPos(bagPos);
+            if (!bag)
+                continue;
+
+            for (uint32 slot = 0; slot < bag->GetBagSize(); ++slot)
+            {
+                if (Item* item = player->GetItemByPos(bagPos, slot))
+                    AddToDatabase(player, item);
+            }
+        }
+
+        for (uint8 slot = BANK_SLOT_ITEM_START; slot < BANK_SLOT_ITEM_END; ++slot)
+        {
+            if (Item* item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
+                AddToDatabase(player, item);
+        }
+
+        for (uint8 bagPos = BANK_SLOT_BAG_START; bagPos < BANK_SLOT_BAG_END; ++bagPos)
+        {
+            Bag* bag = player->GetBagByPos(bagPos);
+            if (!bag)
+                continue;
+
+            for (uint32 slot = 0; slot < bag->GetBagSize(); ++slot)
+            {
+                if (Item* item = player->GetItemByPos(bagPos, slot))
+                    AddToDatabase(player, item);
+            }
+        }
+    }
+
     void CheckRetroActiveQuestAppearances(Player* player)
     {
+        if (!sT->GetUseCollectionSystem())
+            return;
+
         const RewardedQuestSet& rewQuests = player->getRewardedQuests();
         for (RewardedQuestSet::const_iterator itr = rewQuests.begin(); itr != rewQuests.end(); ++itr)
         {
             Quest const* quest = sObjectMgr->GetQuestTemplate(*itr);
             OnPlayerCompleteQuest(player, quest);
         }
+
+        // One-time backfill for already-owned items
+        CheckRetroActiveInventoryAppearances(player);
         player->UpdatePlayerSetting("mod-transmog", SETTING_RETROACTIVE_CHECK, 1);
     }
 public:


### PR DESCRIPTION
### Summary
Previously we've had `CheckRetroActiveQuestAppearances()` method to retroactively collect appearances that were rewarded from completed quests.  This PR adds `CheckRetroActiveInventoryAppearances()` method that runs during the retroactive pass (when `CheckRetroActiveQuestAppearances()` is ran) and collects appearances from items players already own in their inventory or bank.

### What it does
During the one-time retroactive login pass, it now scans:
- Equipped gear
- Backpack
- Bag contents
- Bank slots
- Bank bag contents

### Why
Previously, retroactive handling focused on quest rewards and could miss items already sitting in inventory/bank.

### Notes
- Existing collection eligibility rules are still respected.
- This is a one-time backfill tied to the retroactive check flow.  Retroactive eligibility rules are unchanged.
