### PR TITLE
feat(Core/DB): Add .transmog claim command to collect appearances from bags

### DIFF
--- a/data/sql/db-world/updates/2026_07_23_transmog_claim_strings.sql
+++ b/data/sql/db-world/updates/2026_07_23_transmog_claim_strings.sql
@@ -1,0 +1,91 @@
+-- Strings for the `.transmog claim` command, sent via PSendModuleSysMessage.
+DELETE FROM `module_string` WHERE `module` = 'mod-transmog' AND `id` BETWEEN 81 AND 88;
+INSERT INTO `module_string` (`module`, `id`, `string`) VALUES
+-- Claim command strings
+('mod-transmog', 81, 'Could not claim item: appearance collection is disabled on this server.'),
+('mod-transmog', 82, 'You do not have that item in your bags.'),
+('mod-transmog', 83, 'Usage: .transmog claim [item link], .transmog claim <bag> <slot> (bag 0 = backpack, 1-4 = bags; slots start at 1), or .transmog claim all.'),
+('mod-transmog', 84, 'Invalid bag or slot. Bags are 0 (backpack) to 4, and slots start at 1.'),
+('mod-transmog', 85, 'There is no item in that bag slot.'),
+('mod-transmog', 86, 'Claimed {} new appearance(s) from your bags.'),
+('mod-transmog', 87, 'No new appearances to claim from your bags.'),
+('mod-transmog', 88, 'You have already collected this appearance.');
+
+DELETE FROM `module_string_locale` WHERE `module` = 'mod-transmog' AND `id` BETWEEN 81 AND 88;
+INSERT INTO `module_string_locale` (`module`, `id`, `locale`, `string`) VALUES
+-- ID 81: CLAIM_DISABLED
+('mod-transmog', 81, 'koKR', '아이템을 획득할 수 없습니다: 이 서버에서는 외형 컬렉션이 비활성화되어 있습니다.'),
+('mod-transmog', 81, 'frFR', 'Impossible de collecter l''apparence : la collection d''apparences est désactivée sur ce serveur.'),
+('mod-transmog', 81, 'deDE', 'Gegenstand konnte nicht beansprucht werden: Die Aussehen-Sammlung ist auf diesem Server deaktiviert.'),
+('mod-transmog', 81, 'zhCN', '无法认领物品：本服务器已禁用外观收藏系统。'),
+('mod-transmog', 81, 'zhTW', '無法認領物品：本伺服器已停用外觀收藏系統。'),
+('mod-transmog', 81, 'esES', 'No se pudo reclamar el objeto: la colección de apariencias está desactivada en este servidor.'),
+('mod-transmog', 81, 'esMX', 'No se pudo reclamar el objeto: la colección de apariencias está desactivada en este servidor.'),
+('mod-transmog', 81, 'ruRU', 'Не удалось получить предмет: коллекция обликов отключена на этом сервере.'),
+-- ID 82: CLAIM_NOT_IN_BAGS
+('mod-transmog', 82, 'koKR', '가방에 해당 아이템이 없습니다.'),
+('mod-transmog', 82, 'frFR', 'Vous n''avez pas cet objet dans votre inventaire.'),
+('mod-transmog', 82, 'deDE', 'Du hast diesen Gegenstand nicht in deinen Taschen.'),
+('mod-transmog', 82, 'zhCN', '你的背包中没有该物品。'),
+('mod-transmog', 82, 'zhTW', '你的背包中沒有該物品。'),
+('mod-transmog', 82, 'esES', 'No tienes ese objeto en tus bolsas.'),
+('mod-transmog', 82, 'esMX', 'No tienes ese objeto en tus bolsas.'),
+('mod-transmog', 82, 'ruRU', 'У вас нет этого предмета в сумках.'),
+-- ID 83: CLAIM_USAGE
+('mod-transmog', 83, 'koKR', '사용법: .transmog claim [아이템 링크], .transmog claim <가방> <칸> (가방 0 = 기본 가방, 1-4 = 착용한 가방; 칸은 1부터 시작), 또는 .transmog claim all.'),
+('mod-transmog', 83, 'frFR', 'Utilisation : .transmog claim [lien d''objet], .transmog claim <sac> <emplacement> (sac 0 = sac à dos, 1-4 = sacs ; les emplacements commencent à 1), ou .transmog claim all.'),
+('mod-transmog', 83, 'deDE', 'Verwendung: .transmog claim [Gegenstandslink], .transmog claim <Tasche> <Platz> (Tasche 0 = Rucksack, 1-4 = Taschen; Plätze beginnen bei 1) oder .transmog claim all.'),
+('mod-transmog', 83, 'zhCN', '用法：.transmog claim [物品链接]、.transmog claim <背包> <格子>（背包 0 = 主背包，1-4 = 已装备的背包；格子从 1 开始），或 .transmog claim all。'),
+('mod-transmog', 83, 'zhTW', '用法：.transmog claim [物品連結]、.transmog claim <背包> <格子>（背包 0 = 主背包，1-4 = 已裝備的背包；格子從 1 開始），或 .transmog claim all。'),
+('mod-transmog', 83, 'esES', 'Uso: .transmog claim [enlace de objeto], .transmog claim <bolsa> <espacio> (bolsa 0 = mochila, 1-4 = bolsas; los espacios empiezan en 1), o .transmog claim all.'),
+('mod-transmog', 83, 'esMX', 'Uso: .transmog claim [enlace de objeto], .transmog claim <bolsa> <espacio> (bolsa 0 = mochila, 1-4 = bolsas; los espacios empiezan en 1), o .transmog claim all.'),
+('mod-transmog', 83, 'ruRU', 'Использование: .transmog claim [ссылка на предмет], .transmog claim <сумка> <ячейка> (сумка 0 = рюкзак, 1-4 = сумки; ячейки начинаются с 1), или .transmog claim all.'),
+-- ID 84: CLAIM_INVALID_SLOT
+('mod-transmog', 84, 'koKR', '잘못된 가방 또는 칸입니다. 가방은 0(기본 가방)부터 4까지이며, 칸은 1부터 시작합니다.'),
+('mod-transmog', 84, 'frFR', 'Sac ou emplacement invalide. Les sacs vont de 0 (sac à dos) à 4, et les emplacements commencent à 1.'),
+('mod-transmog', 84, 'deDE', 'Ungültige Tasche oder ungültiger Platz. Taschen gehen von 0 (Rucksack) bis 4, und Plätze beginnen bei 1.'),
+('mod-transmog', 84, 'zhCN', '背包或格子无效。背包为 0（主背包）到 4，格子从 1 开始。'),
+('mod-transmog', 84, 'zhTW', '背包或格子無效。背包為 0（主背包）到 4，格子從 1 開始。'),
+('mod-transmog', 84, 'esES', 'Bolsa o espacio no válido. Las bolsas van de 0 (mochila) a 4, y los espacios empiezan en 1.'),
+('mod-transmog', 84, 'esMX', 'Bolsa o espacio no válido. Las bolsas van de 0 (mochila) a 4, y los espacios empiezan en 1.'),
+('mod-transmog', 84, 'ruRU', 'Неверная сумка или ячейка. Сумки — от 0 (рюкзак) до 4, ячейки начинаются с 1.'),
+-- ID 85: CLAIM_EMPTY_SLOT
+('mod-transmog', 85, 'koKR', '해당 가방 칸에 아이템이 없습니다.'),
+('mod-transmog', 85, 'frFR', 'Aucun objet dans cet emplacement de sac.'),
+('mod-transmog', 85, 'deDE', 'In diesem Taschenplatz befindet sich kein Gegenstand.'),
+('mod-transmog', 85, 'zhCN', '该背包格子中没有物品。'),
+('mod-transmog', 85, 'zhTW', '該背包格子中沒有物品。'),
+('mod-transmog', 85, 'esES', 'No hay ningún objeto en ese espacio de la bolsa.'),
+('mod-transmog', 85, 'esMX', 'No hay ningún objeto en ese espacio de la bolsa.'),
+('mod-transmog', 85, 'ruRU', 'В этой ячейке сумки нет предмета.'),
+-- ID 86: CLAIM_ALL_RESULT
+('mod-transmog', 86, 'koKR', '가방에서 새로운 외형 {}개를 획득했습니다.'),
+('mod-transmog', 86, 'frFR', '{} nouvelle(s) apparence(s) collectée(s) depuis vos sacs.'),
+('mod-transmog', 86, 'deDE', '{} neue(s) Aussehen aus deinen Taschen beansprucht.'),
+('mod-transmog', 86, 'zhCN', '已从背包中认领 {} 个新外观。'),
+('mod-transmog', 86, 'zhTW', '已從背包中認領 {} 個新外觀。'),
+('mod-transmog', 86, 'esES', 'Se reclamaron {} apariencia(s) nueva(s) de tus bolsas.'),
+('mod-transmog', 86, 'esMX', 'Se reclamaron {} apariencia(s) nueva(s) de tus bolsas.'),
+('mod-transmog', 86, 'ruRU', 'Получено новых обликов из сумок: {}.'),
+-- ID 87: CLAIM_ALL_NONE
+('mod-transmog', 87, 'koKR', '가방에서 획득할 새로운 외형이 없습니다.'),
+('mod-transmog', 87, 'frFR', 'Aucune nouvelle apparence à collecter dans vos sacs.'),
+('mod-transmog', 87, 'deDE', 'Keine neuen Aussehen zum Beanspruchen in deinen Taschen.'),
+('mod-transmog', 87, 'zhCN', '背包中没有可认领的新外观。'),
+('mod-transmog', 87, 'zhTW', '背包中沒有可認領的新外觀。'),
+('mod-transmog', 87, 'esES', 'No hay apariencias nuevas que reclamar en tus bolsas.'),
+('mod-transmog', 87, 'esMX', 'No hay apariencias nuevas que reclamar en tus bolsas.'),
+('mod-transmog', 87, 'ruRU', 'В сумках нет новых обликов для получения.'),
+-- ID 88: CLAIM_ALREADY
+('mod-transmog', 88, 'koKR', '이미 이 외형을 수집했습니다.'),
+('mod-transmog', 88, 'frFR', 'Vous avez déjà collecté cette apparence.'),
+('mod-transmog', 88, 'deDE', 'Du hast dieses Aussehen bereits gesammelt.'),
+('mod-transmog', 88, 'zhCN', '你已经收集了该外观。'),
+('mod-transmog', 88, 'zhTW', '你已經收集了該外觀。'),
+('mod-transmog', 88, 'esES', 'Ya has coleccionado esta apariencia.'),
+('mod-transmog', 88, 'esMX', 'Ya has coleccionado esta apariencia.'),
+('mod-transmog', 88, 'ruRU', 'Вы уже собрали этот облик.');
+
+DELETE FROM `command` WHERE `name` = 'transmog claim';
+INSERT INTO `command` (`name`, `security`, `help`) VALUES
+('transmog claim', 0, 'Syntax:\n.transmog claim [item link]\n.transmog claim <bag> <slot>\n.transmog claim all\nClaims the appearance of an item in your bags without equipping it, binding the item to you. Provide a shift-clicked item link, a bag and slot position (bag 0 = backpack, 1-4 = equipped bags; slots start at 1), or "all" to claim every new appearance in your bags.');

--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -479,6 +479,8 @@ bool Transmogrification::AddCollectedAppearance(uint32 accountId, uint32 itemId)
 
 void Transmogrification::AddToDatabase(Player* player, ItemTemplate const* itemTemplate)
 {
+    if (!player || !itemTemplate)
+        return;
     if (!GetTrackUnusableItems() && !SuitableForTransmogrification(player, itemTemplate))
         return;
     if (itemTemplate->Class != ITEM_CLASS_ARMOR && itemTemplate->Class != ITEM_CLASS_WEAPON)

--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -488,9 +488,9 @@ void Transmogrification::AddToDatabase(Player* player, ItemTemplate const* itemT
     uint32 accountId = session->GetAccountId();
     std::string itemName = itemTemplate->Name1;
 
-    int loc_idex = session->GetSessionDbLocaleIndex();
+    int locIndex = session->GetSessionDbLocaleIndex();
     if (ItemLocale const* il = sObjectMgr->GetItemLocale(itemId))
-        ObjectMgr::GetLocaleString(il->Name, loc_idex, itemName);
+        ObjectMgr::GetLocaleString(il->Name, locIndex, itemName);
 
     std::stringstream tempStream;
     tempStream << std::hex << ItemQualityColors[itemTemplate->Quality];

--- a/src/Transmogrification.cpp
+++ b/src/Transmogrification.cpp
@@ -1,8 +1,9 @@
-#include "Transmogrification.h"
-#include "ItemTemplate.h"
 #include "DatabaseEnv.h"
+#include "ItemTemplate.h"
 #include "SpellMgr.h"
 #include "Tokenize.h"
+#include "Transmogrification.h"
+#include "WorldSession.h"
 #include "WorldSessionMgr.h"
 
 Transmogrification* Transmogrification::instance()
@@ -474,6 +475,34 @@ bool Transmogrification::AddCollectedAppearance(uint32 accountId, uint32 itemId)
     auto res = collectionCache[accountId].insert(itemId);
     bool inserted = res.second;
     return inserted;
+}
+
+void Transmogrification::AddToDatabase(Player* player, ItemTemplate const* itemTemplate)
+{
+    if (!GetTrackUnusableItems() && !SuitableForTransmogrification(player, itemTemplate))
+        return;
+    if (itemTemplate->Class != ITEM_CLASS_ARMOR && itemTemplate->Class != ITEM_CLASS_WEAPON)
+        return;
+    uint32 itemId = itemTemplate->ItemId;
+    WorldSession* session = player->GetSession();
+    uint32 accountId = session->GetAccountId();
+    std::string itemName = itemTemplate->Name1;
+
+    int loc_idex = session->GetSessionDbLocaleIndex();
+    if (ItemLocale const* il = sObjectMgr->GetItemLocale(itemId))
+        ObjectMgr::GetLocaleString(il->Name, loc_idex, itemName);
+
+    std::stringstream tempStream;
+    tempStream << std::hex << ItemQualityColors[itemTemplate->Quality];
+    std::string itemQuality = tempStream.str();
+    bool showChatMessage = !(player->GetPlayerSetting("mod-transmog", SETTING_HIDE_TRANSMOG).value) && !CanNeverTransmog(itemTemplate);
+    if (AddCollectedAppearance(accountId, itemId))
+    {
+        if (showChatMessage)
+            ChatHandler(session).PSendSysMessage(R"(|c{}|Hitem:{}:0:0:0:0:0:0:0:0|h[{}]|h|r {})", itemQuality, itemId, itemName, *session->GetModuleString("mod-transmog", LANG_TRANSMOG_ADDED_APPEARANCE));
+
+        CharacterDatabase.Execute("INSERT INTO custom_unlocked_appearances (account_id, item_template_id) VALUES ({}, {})", accountId, itemId);
+    }
 }
 
 TransmogStrings Transmogrification::Transmogrify(Player* player, uint32 itemEntry, uint8 slot, /*uint32 newEntry, */bool no_cost) {

--- a/src/Transmogrification.h
+++ b/src/Transmogrification.h
@@ -137,6 +137,15 @@ enum TransmogStrings : uint32
     LANG_TRANSMOG_CHECK_COLL_NOT_FOUND         = 79,
     // Check command: section pass message (shared by all sections)
     LANG_TRANSMOG_CHECK_SECTION_OK             = 80,
+    // Claim command strings
+    LANG_TRANSMOG_CMD_CLAIM_DISABLED           = 81,
+    LANG_TRANSMOG_CMD_CLAIM_NOT_IN_BAGS        = 82,
+    LANG_TRANSMOG_CMD_CLAIM_USAGE              = 83,
+    LANG_TRANSMOG_CMD_CLAIM_INVALID_SLOT       = 84,
+    LANG_TRANSMOG_CMD_CLAIM_EMPTY_SLOT         = 85,
+    LANG_TRANSMOG_CMD_CLAIM_ALL_RESULT         = 86,
+    LANG_TRANSMOG_CMD_CLAIM_ALL_NONE           = 87,
+    LANG_TRANSMOG_CMD_CLAIM_ALREADY            = 88,
 };
 
 enum ArmorClassSpellIDs
@@ -295,6 +304,10 @@ public:
     void DeleteFakeEntry(Player* player, uint8 slot, Item* itemTransmogrified, CharacterDatabaseTransaction* trans = nullptr);
     void SetFakeEntry(Player* player, uint32 newEntry, uint8 slot, Item* itemTransmogrified);
     bool AddCollectedAppearance(uint32 accountId, uint32 itemId);
+    // Adds the item's appearance to the player's account collection and, if newly unlocked,
+    // notifies the player (LANG_TRANSMOG_ADDED_APPEARANCE). Shared by the auto-collect player
+    // script and the `.transmog claim` command.
+    void AddToDatabase(Player* player, ItemTemplate const* itemTemplate);
 
     TransmogStrings Transmogrify(Player* player, ObjectGuid itemGUID, uint8 slot, /*uint32 newEntry, */bool no_cost = false);
     TransmogStrings Transmogrify(Player* player, uint32 itemEntry, uint8 slot, /*uint32 newEntry, */bool no_cost = false);

--- a/src/cs_transmog.cpp
+++ b/src/cs_transmog.cpp
@@ -15,14 +15,15 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "Bag.h"
 #include "Chat.h"
+#include "DatabaseEnv.h"
+#include "Item.h"
 #include "ObjectMgr.h"
 #include "Player.h"
 #include "ScriptMgr.h"
-#include "Transmogrification.h"
-#include "Tokenize.h"
-#include "DatabaseEnv.h"
 #include "SpellMgr.h"
+#include "Transmogrification.h"
 
 using namespace Acore::ChatCommands;
 
@@ -46,6 +47,7 @@ public:
             { "",           HandleDisableTransMogVisual,   SEC_PLAYER,        Console::No  },
             { "sync",       HandleSyncTransMogCommand,     SEC_PLAYER,        Console::No  },
             { "portable",   HandleTransmogPortableCommand, SEC_PLAYER,        Console::No  },
+            { "claim",      HandleClaimCommand,            SEC_PLAYER,        Console::No  },
             { "interface",  HandleInterfaceOption,         SEC_PLAYER,        Console::No  },
             { "disclaimer", HandleDisclaimerOption,        SEC_PLAYER,        Console::No  },
             { "reload",     HandleReloadTransmogConfig,    SEC_ADMINISTRATOR, Console::Yes }
@@ -311,6 +313,187 @@ public:
         player->CastSpell((Unit*)nullptr, sTransmogrification->PetSpellId, true);
         return true;
     };
+
+    enum class ClaimResult
+    {
+        Claimed,
+        AlreadyOwned,
+        Unsuitable
+    };
+
+    // Binds the item to the player, strips its refundable/BoP-tradeable flags and unlocks its
+    // appearance in the account collection. Sends no feedback of its own; the caller decides what to
+    // report. AddToDatabase shows the per-item "new appearance" message when the appearance is new.
+    static ClaimResult TryClaimItem(Player* player, Item* item)
+    {
+        ItemTemplate const* itemTemplate = item->GetTemplate();
+
+        // Only allow claiming if the character could actually equip the item.
+        if (!sTransmogrification->SuitableForTransmogrification(player, itemTemplate))
+            return ClaimResult::Unsuitable;
+
+        uint32 accountId = player->GetSession()->GetAccountId();
+        auto accIt = sTransmogrification->collectionCache.find(accountId);
+        if (accIt != sTransmogrification->collectionCache.end() && accIt->second.contains(itemTemplate->ItemId))
+            return ClaimResult::AlreadyOwned;
+
+        // Claim the physical item: bind it to the player and drop the refundable/BoP-tradeable flags
+        // so the appearance can't be collected and then refunded to a vendor or traded away.
+        item->SetOwnerGUID(player->GetGUID());
+        item->SetNotRefundable(player);
+        if (!sTransmogrification->GetAllowTradeable())
+            item->ClearSoulboundTradeable(player);
+        item->SetBinding(true);
+        item->SetState(ITEM_CHANGED, player);
+
+        // Unlock the appearance and show the "added to your appearance collection" message (LANG_TRANSMOG_ADDED_APPEARANCE).
+        sTransmogrification->AddToDatabase(player, itemTemplate);
+        return ClaimResult::Claimed;
+    }
+
+    // Claims item appearances held in the player's bags without having to equip them. Forms:
+    //   .transmog claim [item link]  - first instance of that item in the player's bags
+    //   .transmog claim <bag> <slot> - WoW client numbering: bag 0 = backpack, 1-4 = equipped bags,
+    //                                  slots start at 1 (matches GetContainerItemInfo).
+    //   .transmog claim all          - every unknown, claimable appearance in the player's bags
+    static bool HandleClaimCommand(ChatHandler* handler, Variant<Hyperlink<Acore::Hyperlinks::LinkTags::item>, EXACT_SEQUENCE("all"), uint8> claimArg, Optional<uint8> slotArg)
+    {
+        if (!sTransmogrification->GetUseCollectionSystem())
+        {
+            handler->PSendModuleSysMessage("mod-transmog", LANG_TRANSMOG_CMD_CLAIM_DISABLED);
+            handler->SetSentErrorMessage(true);
+            return true;
+        }
+
+        Player* player = handler->GetPlayer();
+        if (!player)
+            return false;
+
+        // .transmog claim all - sweep every item in the backpack and equipped bags.
+        if (claimArg.holds_alternative<EXACT_SEQUENCE("all")>())
+        {
+            uint32 claimed = 0;
+
+            auto claimSlot = [&](Item* bagItem)
+            {
+                if (bagItem && TryClaimItem(player, bagItem) == ClaimResult::Claimed)
+                    ++claimed;
+            };
+
+            for (uint8 slot = INVENTORY_SLOT_ITEM_START; slot < INVENTORY_SLOT_ITEM_END; ++slot)
+                claimSlot(player->GetItemByPos(INVENTORY_SLOT_BAG_0, slot));
+
+            for (uint8 bag = INVENTORY_SLOT_BAG_START; bag < INVENTORY_SLOT_BAG_END; ++bag)
+            {
+                Bag* pBag = player->GetBagByPos(bag);
+                if (!pBag)
+                    continue;
+                for (uint32 slot = 0; slot < pBag->GetBagSize(); ++slot)
+                    claimSlot(player->GetItemByPos(bag, slot));
+            }
+
+            if (claimed)
+            {
+                handler->PSendModuleSysMessage("mod-transmog", LANG_TRANSMOG_CMD_CLAIM_ALL_RESULT, claimed);
+            }
+            else
+            {
+                handler->PSendModuleSysMessage("mod-transmog", LANG_TRANSMOG_CMD_CLAIM_ALL_NONE);
+                handler->SetSentErrorMessage(true);
+            }
+            return true;
+        }
+
+        // Otherwise resolve a single item, either from a shift-clicked link or a bag/slot position.
+        Item* item = nullptr;
+
+        if (claimArg.holds_alternative<Hyperlink<Acore::Hyperlinks::LinkTags::item>>())
+        {
+            // Item-link form: claim the first instance of this item held in the player's bags.
+            uint32 itemId = claimArg.get<Hyperlink<Acore::Hyperlinks::LinkTags::item>>()->Item->ItemId;
+
+            // Backpack
+            for (uint8 slot = INVENTORY_SLOT_ITEM_START; !item && slot < INVENTORY_SLOT_ITEM_END; ++slot)
+                if (Item* bagItem = player->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
+                    if (bagItem->GetEntry() == itemId)
+                        item = bagItem;
+
+            // Equipped bags
+            for (uint8 bag = INVENTORY_SLOT_BAG_START; !item && bag < INVENTORY_SLOT_BAG_END; ++bag)
+            {
+                Bag* pBag = player->GetBagByPos(bag);
+                if (!pBag)
+                    continue;
+                for (uint32 slot = 0; !item && slot < pBag->GetBagSize(); ++slot)
+                    if (Item* bagItem = player->GetItemByPos(bag, slot))
+                        if (bagItem->GetEntry() == itemId)
+                            item = bagItem;
+            }
+
+            if (!item)
+            {
+                handler->PSendModuleSysMessage("mod-transmog", LANG_TRANSMOG_CMD_CLAIM_NOT_IN_BAGS);
+                handler->SetSentErrorMessage(true);
+                return true;
+            }
+        }
+        else
+        {
+            // Bag/slot form: WoW client numbering (bag 0 = backpack, 1-4 = equipped bags; 1-based slot).
+            uint8 bag = claimArg.get<uint8>();
+            if (!slotArg)
+            {
+                handler->PSendModuleSysMessage("mod-transmog", LANG_TRANSMOG_CMD_CLAIM_USAGE);
+                handler->SetSentErrorMessage(true);
+                return true;
+            }
+
+            uint8 wowSlot = *slotArg;
+            if (bag > 4 || wowSlot == 0)
+            {
+                handler->PSendModuleSysMessage("mod-transmog", LANG_TRANSMOG_CMD_CLAIM_INVALID_SLOT);
+                handler->SetSentErrorMessage(true);
+                return true;
+            }
+
+            if (bag == 0)
+            {
+                // Backpack: WoW slot 1 maps to INVENTORY_SLOT_ITEM_START.
+                if (wowSlot <= INVENTORY_SLOT_ITEM_END - INVENTORY_SLOT_ITEM_START)
+                    item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, INVENTORY_SLOT_ITEM_START + wowSlot - 1);
+            }
+            else
+            {
+                // Equipped bag: WoW bag 1-4 maps to INVENTORY_SLOT_BAG_START + (bag - 1).
+                uint8 bagPos = INVENTORY_SLOT_BAG_START + (bag - 1);
+                if (Bag* pBag = player->GetBagByPos(bagPos))
+                    if (wowSlot <= pBag->GetBagSize())
+                        item = player->GetItemByPos(bagPos, wowSlot - 1);
+            }
+
+            if (!item)
+            {
+                handler->PSendModuleSysMessage("mod-transmog", LANG_TRANSMOG_CMD_CLAIM_EMPTY_SLOT);
+                handler->SetSentErrorMessage(true);
+                return true;
+            }
+        }
+
+        switch (TryClaimItem(player, item))
+        {
+            case ClaimResult::Unsuitable:
+                handler->PSendModuleSysMessage("mod-transmog", LANG_TRANSMOG_CMD_ADD_UNSUITABLE);
+                handler->SetSentErrorMessage(true);
+                break;
+            case ClaimResult::AlreadyOwned:
+                handler->PSendModuleSysMessage("mod-transmog", LANG_TRANSMOG_CMD_CLAIM_ALREADY);
+                handler->SetSentErrorMessage(true);
+                break;
+            case ClaimResult::Claimed:
+                break; // AddToDatabase already announced the new appearance.
+        }
+        return true;
+    }
 
     static bool HandleInterfaceOption(ChatHandler* handler, bool enable)
     {

--- a/src/cs_transmog.cpp
+++ b/src/cs_transmog.cpp
@@ -459,16 +459,29 @@ public:
             if (bag == 0)
             {
                 // Backpack: WoW slot 1 maps to INVENTORY_SLOT_ITEM_START.
-                if (wowSlot <= INVENTORY_SLOT_ITEM_END - INVENTORY_SLOT_ITEM_START)
-                    item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, INVENTORY_SLOT_ITEM_START + wowSlot - 1);
+                uint8 maxSlots = INVENTORY_SLOT_ITEM_END - INVENTORY_SLOT_ITEM_START;
+                if (wowSlot > maxSlots)
+                {
+                    handler->PSendModuleSysMessage("mod-transmog", LANG_TRANSMOG_CMD_CLAIM_INVALID_SLOT);
+                    handler->SetSentErrorMessage(true);
+                    return true;
+                }
+
+                item = player->GetItemByPos(INVENTORY_SLOT_BAG_0, INVENTORY_SLOT_ITEM_START + wowSlot - 1);
             }
             else
             {
                 // Equipped bag: WoW bag 1-4 maps to INVENTORY_SLOT_BAG_START + (bag - 1).
                 uint8 bagPos = INVENTORY_SLOT_BAG_START + (bag - 1);
-                if (Bag* pBag = player->GetBagByPos(bagPos))
-                    if (wowSlot <= pBag->GetBagSize())
-                        item = player->GetItemByPos(bagPos, wowSlot - 1);
+                Bag* pBag = player->GetBagByPos(bagPos);
+                if (!pBag || wowSlot > pBag->GetBagSize())
+                {
+                    handler->PSendModuleSysMessage("mod-transmog", LANG_TRANSMOG_CMD_CLAIM_INVALID_SLOT);
+                    handler->SetSentErrorMessage(true);
+                    return true;
+                }
+
+                item = player->GetItemByPos(bagPos, wowSlot - 1);
             }
 
             if (!item)

--- a/src/cs_transmog.cpp
+++ b/src/cs_transmog.cpp
@@ -145,9 +145,9 @@ public:
 
         if (target) {
             // get locale item name
-            int loc_idex = target->GetSession()->GetSessionDbLocaleIndex();
+            int locIndex = target->GetSession()->GetSessionDbLocaleIndex();
             if (ItemLocale const* il = sObjectMgr->GetItemLocale(itemId))
-                ObjectMgr::GetLocaleString(il->Name, loc_idex, itemName);
+                ObjectMgr::GetLocaleString(il->Name, locIndex, itemName);
         }
 
         std::string playerName = player->GetName();

--- a/src/transmog_scripts.cpp
+++ b/src/transmog_scripts.cpp
@@ -702,30 +702,7 @@ private:
 
     void AddToDatabase(Player* player, ItemTemplate const* itemTemplate)
     {
-        if (!sT->GetTrackUnusableItems() && !sT->SuitableForTransmogrification(player, itemTemplate))
-            return;
-        if (itemTemplate->Class != ITEM_CLASS_ARMOR && itemTemplate->Class != ITEM_CLASS_WEAPON)
-            return;
-        uint32 itemId = itemTemplate->ItemId;
-        WorldSession* session = player->GetSession();
-        uint32 accountId = session->GetAccountId();
-        std::string itemName = itemTemplate->Name1;
-
-        int loc_idex = session->GetSessionDbLocaleIndex();
-        if (ItemLocale const* il = sObjectMgr->GetItemLocale(itemId))
-            ObjectMgr::GetLocaleString(il->Name, loc_idex, itemName);
-
-        std::stringstream tempStream;
-        tempStream << std::hex << ItemQualityColors[itemTemplate->Quality];
-        std::string itemQuality = tempStream.str();
-        bool showChatMessage = !(player->GetPlayerSetting("mod-transmog", SETTING_HIDE_TRANSMOG).value) && !sT->CanNeverTransmog(itemTemplate);
-        if (sT->AddCollectedAppearance(accountId, itemId))
-        {
-            if (showChatMessage)
-                ChatHandler(session).PSendSysMessage(R"(|c{}|Hitem:{}:0:0:0:0:0:0:0:0|h[{}]|h|r {})", itemQuality, itemId, itemName, Tstr(session, LANG_TRANSMOG_ADDED_APPEARANCE));
-
-            CharacterDatabase.Execute("INSERT INTO custom_unlocked_appearances (account_id, item_template_id) VALUES ({}, {})", accountId, itemId);
-        }
+        sT->AddToDatabase(player, itemTemplate);
     }
 
     void CheckRetroActiveInventoryAppearances(Player* player)


### PR DESCRIPTION
## Description

Adds a new `.transmog claim` player command that unlocks an item's appearance from the player's **bags** without having to equip it. This enables:

- Building addons that quickly collect appearances from bag items.
- Collecting appearances while using game modes that prevent equipping certain items (e.g. challenge modes).

### Command forms

| Form | Behavior |
| --- | --- |
| `.transmog claim [item link]` | Claims the first instance of a shift-clicked item found in the player's bags. |
| `.transmog claim <bag> <slot>` | Claims the item at a bag/slot position using WoW client numbering: bag `0` = backpack, `1`-`4` = equipped bags; slots start at `1` (matches `GetContainerItemInfo`). |
| `.transmog claim all` | Sweeps the backpack and equipped bags, claiming every new, eligible appearance. |

### Behavior / safeguards

- **Eligibility** is checked with `SuitableForTransmogrification`, **not** `Player::CanUseItem` — challenge modes hook `CanUseItem` to block equipping, which would give wrong results here.
- Claiming **binds the item** to the player and **strips the refundable / BoP-tradeable flags**, so an appearance can't be claimed and then refunded to a vendor or traded away. The BoP-tradeable strip is skipped when `AllowTradeable` is enabled (nothing to gain by stripping it there).
- Requires the collection system (`UseCollectionSystem`) to be enabled.
- Shows the standard "new appearance" message per unlocked item (`LANG_TRANSMOG_ADDED_APPEARANCE`).

### Implementation notes

- The `AddToDatabase` appearance-unlock logic is moved from the player script (`transmog_scripts.cpp`) into `Transmogrification` so both the `PlayerScript` (auto-collect hooks) and the new command share a single implementation.
- New `module_string` entries (IDs 81-88) hold the command messages with full locale coverage (koKR/frFR/deDE/zhCN/zhTW/esES/esMX/ruRU), plus a `command` help row — delivered via `data/sql/db-world/updates/2026_07_23_transmog_claim_strings.sql`.

## How to test

1. Apply the world DB update (or restart with auto-updates) and build the module.
2. With `Transmogrification.UseCollectionSystem = 1`, put an equippable, un-collected armor/weapon in your bags.
3. Run `.transmog claim [shift-clicked item]`, `.transmog claim 0 1`, or `.transmog claim all` — the appearance unlocks and the item becomes soulbound and non-refundable.
4. Confirm unequippable items (wrong class/level/faction/etc.) are rejected, and already-owned appearances are reported as such.

Verified locally: C++ (`apps/codestyle/codestyle-cpp.py`) and SQL (`apps/codestyle/codestyle-sql.py`) codestyle checks pass. Compiled and ran in-game by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a **`.transmog claim`** command to unlock transmogrification appearances from a bag slot, item link, or **all** eligible items in bags.
  * Added localized feedback messages for disabled state, usage errors, invalid/empty slots, unsuitable items, already-claimed appearances, and newly unlocked appearances.

* **Bug Fixes**
  * Improved how appearances are recorded and how claim notifications are delivered when new appearances are successfully unlocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->